### PR TITLE
feat: use verifyWithIndividualChecks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1118,9 +1118,9 @@
       }
     },
     "@govtechsg/oa-verify": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@govtechsg/oa-verify/-/oa-verify-2.0.2.tgz",
-      "integrity": "sha512-DgfVRmsCnW4H60i5kKYH3OeTFbkMpDFmMDLkM8UICN91j89IqLPCMy4BvYf1qVqyRjqz5H/Xu4g+KEc0cScaEg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@govtechsg/oa-verify/-/oa-verify-2.1.0.tgz",
+      "integrity": "sha512-PxIM4FfVZQsTbab7NEnu5yZGnhGkTP/JSD0EmjTXqCsKdbmYttXGtFwf//fpjv3ig4i/XU5ZX0rAmVEhb6MaLg==",
       "requires": {
         "@govtechsg/open-attestation": "^1.1.41",
         "ethers": "^4.0.27"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@govtechsg/dnsprove": "^2.0.5",
-    "@govtechsg/oa-verify": "^2.0.2",
+    "@govtechsg/oa-verify": "^2.1.0",
     "@govtechsg/open-attestation": "^1.1.41",
     "expo": "^35.0.0",
     "expo-camera": "^7.0.0",

--- a/src/common/hooks/useDocumentVerifier.test.tsx
+++ b/src/common/hooks/useDocumentVerifier.test.tsx
@@ -14,19 +14,14 @@ describe("useDocumentVerifier", () => {
   it("should return the correct check status as the checks resolve at different times", async () => {
     expect.assertions(3);
     mockCheckValidity.mockReturnValue([
-      // verifyHashIssuedRevoked
-      new Promise(res =>
-        setTimeout(
-          () =>
-            res({
-              hash: { checksumMatch: true },
-              issued: { issuedOnAll: true },
-              revoked: { revokedOnAny: false },
-              valid: true
-            }),
-          500
-        )
-      ),
+      // verifyHash
+      new Promise(res => setTimeout(() => res({ checksumMatch: true }), 500)),
+
+      // verifyIssued
+      new Promise(res => setTimeout(() => res({ issuedOnAll: true }), 500)),
+
+      // verifyRevoked
+      new Promise(res => setTimeout(() => res({ revokedOnAny: false }), 1000)),
 
       // verifyIdentity
       new Promise(res =>
@@ -55,7 +50,7 @@ describe("useDocumentVerifier", () => {
     expect(result.current).toStrictEqual({
       tamperedCheck: CheckStatus.VALID,
       issuedCheck: CheckStatus.VALID,
-      revokedCheck: CheckStatus.VALID,
+      revokedCheck: CheckStatus.CHECKING,
       issuerCheck: CheckStatus.CHECKING,
       overallValidity: CheckStatus.CHECKING
     });

--- a/src/common/hooks/useDocumentVerifier.tsx
+++ b/src/common/hooks/useDocumentVerifier.tsx
@@ -22,28 +22,31 @@ export const useDocumentVerifier = (
 
   useEffect(() => {
     const [
-      verifyHashIssuedRevoked,
+      verifyHash,
+      verifyIssued,
+      verifyRevoked,
       verifyIdentity,
       overallValidityCheck
     ] = checkValidity(document);
 
-    verifyHashIssuedRevoked.then(v => {
+    verifyHash.then(v =>
       setTamperedCheck(
-        v.hash.checksumMatch ? CheckStatus.VALID : CheckStatus.INVALID
-      );
-      setIssuedCheck(
-        v.issued.issuedOnAll ? CheckStatus.VALID : CheckStatus.INVALID
-      );
-      setRevokedCheck(
-        v.revoked.revokedOnAny ? CheckStatus.INVALID : CheckStatus.VALID
-      );
-    });
+        v.checksumMatch ? CheckStatus.VALID : CheckStatus.INVALID
+      )
+    );
+    verifyIssued.then(v =>
+      setIssuedCheck(v.issuedOnAll ? CheckStatus.VALID : CheckStatus.INVALID)
+    );
 
-    verifyIdentity.then(v => {
+    verifyRevoked.then(v =>
+      setRevokedCheck(v.revokedOnAny ? CheckStatus.INVALID : CheckStatus.VALID)
+    );
+
+    verifyIdentity.then(v =>
       setIssuerCheck(
         v.identifiedOnAll ? CheckStatus.VALID : CheckStatus.INVALID
-      );
-    });
+      )
+    );
 
     overallValidityCheck.then(v => {
       setOverallValidity(v ? CheckStatus.VALID : CheckStatus.INVALID);

--- a/src/services/DocumentVerifier.test.ts
+++ b/src/services/DocumentVerifier.test.ts
@@ -19,8 +19,8 @@ const truthyVerifyResult = [
 ];
 
 const falsyVerifyResult = [
-  { checksumMatch: true },
-  { issuedOnAll: true },
+  { checksumMatch: false },
+  { issuedOnAll: false },
   { revokedOnAny: true }
 ];
 

--- a/src/services/DocumentVerifier.test.ts
+++ b/src/services/DocumentVerifier.test.ts
@@ -2,9 +2,9 @@ import sampleDoc from "../../fixtures/demo-caas.json";
 import { SignedDocument } from "@govtechsg/open-attestation";
 import { checkValidity } from "./DocumentVerifier";
 
-import verify from "@govtechsg/oa-verify";
+import { verifyWithIndividualChecks } from "@govtechsg/oa-verify";
 jest.mock("@govtechsg/oa-verify");
-const mockVerify = verify as jest.Mock;
+const mockVerifyWithIndividualChecks = verifyWithIndividualChecks as jest.Mock;
 
 import { checkValidIdentity } from "./IdentityVerifier";
 jest.mock("./IdentityVerifier");
@@ -12,19 +12,17 @@ const mockCheckValidIdentity = checkValidIdentity as jest.Mock;
 
 jest.useFakeTimers();
 
-const truthyVerifyResult = {
-  hash: { checksumMatch: true },
-  issued: { issuedOnAll: true },
-  revoked: { revokedOnAny: false },
-  valid: true
-};
+const truthyVerifyResult = [
+  { checksumMatch: true },
+  { issuedOnAll: true },
+  { revokedOnAny: false }
+];
 
-const falsyVerifyResult = {
-  hash: { checksumMatch: true },
-  issued: { issuedOnAll: true },
-  revoked: { revokedOnAny: true },
-  valid: false
-};
+const falsyVerifyResult = [
+  { checksumMatch: true },
+  { issuedOnAll: true },
+  { revokedOnAny: true }
+];
 
 const truthyIdentityResult = {
   identifiedOnAll: true
@@ -39,16 +37,26 @@ describe("ValidityChecker", () => {
     describe("when verify and checkValidIdentity return truthy results", () => {
       it("should return promises that resolve to the truthy result", async () => {
         expect.assertions(3);
-        mockVerify.mockResolvedValue(truthyVerifyResult);
+        mockVerifyWithIndividualChecks.mockReturnValue(
+          truthyVerifyResult.map(Promise.resolve)
+        );
         mockCheckValidIdentity.mockResolvedValue(truthyIdentityResult);
 
         const [
-          verifyHashIssuedRevoked,
+          verifyHash,
+          verifyIssued,
+          verifyRevoked,
           verifyIdentity,
           overallValidityCheck
         ] = checkValidity(sampleDoc as SignedDocument);
 
-        expect(await verifyHashIssuedRevoked).toBe(truthyVerifyResult);
+        const result = await Promise.all([
+          verifyHash,
+          verifyIssued,
+          verifyRevoked
+        ]);
+
+        expect(result).toStrictEqual(truthyVerifyResult);
         expect(await verifyIdentity).toBe(truthyIdentityResult);
         expect(await overallValidityCheck).toBe(true);
       });
@@ -57,16 +65,26 @@ describe("ValidityChecker", () => {
     describe("when verify and checkValidIdentity return falsy results", () => {
       it("should return promises that resolve to the falsy result", async () => {
         expect.assertions(3);
-        mockVerify.mockResolvedValue(falsyVerifyResult);
+        mockVerifyWithIndividualChecks.mockReturnValue(
+          falsyVerifyResult.map(Promise.resolve)
+        );
         mockCheckValidIdentity.mockResolvedValue(falsyIdentityResult);
 
         const [
-          verifyHashIssuedRevoked,
+          verifyHash,
+          verifyIssued,
+          verifyRevoked,
           verifyIdentity,
           overallValidityCheck
         ] = checkValidity(sampleDoc as SignedDocument);
 
-        expect(await verifyHashIssuedRevoked).toBe(falsyVerifyResult);
+        const result = await Promise.all([
+          verifyHash,
+          verifyIssued,
+          verifyRevoked
+        ]);
+
+        expect(result).toStrictEqual(falsyVerifyResult);
         expect(await verifyIdentity).toBe(falsyIdentityResult);
         expect(await overallValidityCheck).toBe(false);
       });
@@ -75,23 +93,35 @@ describe("ValidityChecker", () => {
     describe("when verify returns truthy result and checkValidIdentity returns falsy result", () => {
       it("should return promises that resolve to the falsy result", async () => {
         expect.assertions(3);
-        mockVerify.mockResolvedValue(truthyVerifyResult);
+        mockVerifyWithIndividualChecks.mockReturnValue(
+          truthyVerifyResult.map(Promise.resolve)
+        );
         mockCheckValidIdentity.mockResolvedValue(falsyIdentityResult);
 
         const [
-          verifyHashIssuedRevoked,
+          verifyHash,
+          verifyIssued,
+          verifyRevoked,
           verifyIdentity,
           overallValidityCheck
         ] = checkValidity(sampleDoc as SignedDocument);
 
-        expect(await verifyHashIssuedRevoked).toBe(truthyVerifyResult);
+        const result = await Promise.all([
+          verifyHash,
+          verifyIssued,
+          verifyRevoked
+        ]);
+
+        expect(result).toStrictEqual(truthyVerifyResult);
         expect(await verifyIdentity).toBe(falsyIdentityResult);
         expect(await overallValidityCheck).toBe(false);
       });
 
       it("should wait till certain about the result before returning the overall validity", async () => {
         expect.assertions(3);
-        mockVerify.mockResolvedValue(truthyVerifyResult);
+        mockVerifyWithIndividualChecks.mockReturnValue(
+          truthyVerifyResult.map(Promise.resolve)
+        );
         mockCheckValidIdentity.mockImplementation(
           () =>
             new Promise(res => setTimeout(() => res(falsyIdentityResult), 1000))
@@ -99,13 +129,15 @@ describe("ValidityChecker", () => {
 
         let hasResolvedOverallValidity = false;
         const [
-          verifyHashIssuedRevoked,
+          verifyHash,
+          verifyIssued,
+          verifyRevoked,
           verifyIdentity,
           overallValidityCheck
         ] = checkValidity(sampleDoc as SignedDocument);
         overallValidityCheck.then(() => (hasResolvedOverallValidity = true));
 
-        await verifyHashIssuedRevoked;
+        await Promise.all([verifyHash, verifyIssued, verifyRevoked]);
         expect(hasResolvedOverallValidity).toBe(false); // Can't be certain about the overall validity yet
 
         jest.advanceTimersByTime(1000);
@@ -117,18 +149,26 @@ describe("ValidityChecker", () => {
 
       it("should return overall validity early once the first invalid check is returned", async () => {
         expect.assertions(3);
-        mockVerify.mockImplementation(
-          () =>
-            new Promise(res => setTimeout(() => res(truthyVerifyResult), 1000))
+        mockVerifyWithIndividualChecks.mockReturnValue(
+          truthyVerifyResult.map(
+            result => new Promise(res => setTimeout(() => res(result), 1000))
+          )
         );
         mockCheckValidIdentity.mockResolvedValue(falsyIdentityResult);
 
         let hasResolvedVerify = false;
         const [
-          verifyHashIssuedRevoked,
+          verifyHash,
+          verifyIssued,
+          verifyRevoked,
           verifyIdentity,
           overallValidityCheck
         ] = checkValidity(sampleDoc as SignedDocument);
+        const verifyHashIssuedRevoked = Promise.all([
+          verifyHash,
+          verifyIssued,
+          verifyRevoked
+        ]);
         verifyHashIssuedRevoked.then(() => (hasResolvedVerify = true));
 
         await verifyIdentity; // Since identity result is falsy, document is overall invalid
@@ -145,16 +185,26 @@ describe("ValidityChecker", () => {
     describe("when verify returns falsy result and checkValidIdentity returns truthy result", () => {
       it("should return promises that resolve to the falsy result", async () => {
         expect.assertions(3);
-        mockVerify.mockResolvedValue(falsyVerifyResult);
+        mockVerifyWithIndividualChecks.mockReturnValue(
+          falsyVerifyResult.map(Promise.resolve)
+        );
         mockCheckValidIdentity.mockResolvedValue(truthyIdentityResult);
 
         const [
-          verifyHashIssuedRevoked,
+          verifyHash,
+          verifyIssued,
+          verifyRevoked,
           verifyIdentity,
           overallValidityCheck
         ] = checkValidity(sampleDoc as SignedDocument);
 
-        expect(await verifyHashIssuedRevoked).toBe(falsyVerifyResult);
+        const result = await Promise.all([
+          verifyHash,
+          verifyIssued,
+          verifyRevoked
+        ]);
+
+        expect(result).toStrictEqual(falsyVerifyResult);
         expect(await verifyIdentity).toBe(truthyIdentityResult);
         expect(await overallValidityCheck).toBe(false);
       });

--- a/src/services/DocumentVerifier.ts
+++ b/src/services/DocumentVerifier.ts
@@ -1,25 +1,39 @@
-import verify from "@govtechsg/oa-verify";
+import { verifyWithIndividualChecks } from "@govtechsg/oa-verify";
 import { SignedDocument } from "@govtechsg/open-attestation";
 import { checkValidIdentity } from "./IdentityVerifier";
 
+// Ensures TS infers the type of the array as a tuple instead
+// https://github.com/Microsoft/TypeScript/pull/24897
+function tuple<T extends any[]>(...data: T): T {
+  return data;
+}
+
+// Let TS infer the return type
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const checkValidity = (
   document: SignedDocument,
   network = "ropsten" // TODO: handle this based on some user selection of the network
-): [
-  ReturnType<typeof verify>,
-  ReturnType<typeof checkValidIdentity>,
-  Promise<boolean>
-] => {
+) => {
   const isMainnet = network === "mainnet";
   const networkName = isMainnet ? "homestead" : "ropsten";
 
-  const verifyHashIssuedRevoked = verify(document, networkName);
+  const [verifyHash, verifyIssued, verifyRevoked] = verifyWithIndividualChecks(
+    document,
+    networkName
+  );
+
   const verifyIdentity = checkValidIdentity(document, networkName);
 
   // If any of the checks are invalid, resolve the overall validity early
   const overallValidityCheck = Promise.all([
     new Promise(async (resolve, reject) =>
-      (await verifyHashIssuedRevoked).valid ? resolve() : reject()
+      (await verifyHash).checksumMatch ? resolve() : reject()
+    ),
+    new Promise(async (resolve, reject) =>
+      (await verifyIssued).issuedOnAll ? resolve() : reject()
+    ),
+    new Promise(async (resolve, reject) =>
+      (await verifyRevoked).revokedOnAny ? reject() : resolve()
     ),
     new Promise(async (resolve, reject) =>
       (await verifyIdentity).identifiedOnAll ? resolve() : reject()
@@ -28,5 +42,11 @@ export const checkValidity = (
     .then(() => true)
     .catch(() => false);
 
-  return [verifyHashIssuedRevoked, verifyIdentity, overallValidityCheck];
+  return tuple(
+    verifyHash,
+    verifyIssued,
+    verifyRevoked,
+    verifyIdentity,
+    overallValidityCheck
+  );
 };

--- a/storybook/stories/ValidityBanner/index.tsx
+++ b/storybook/stories/ValidityBanner/index.tsx
@@ -1,20 +1,19 @@
 import React, { useState, useEffect, FunctionComponent, useRef } from "react";
 import { storiesOf } from "@storybook/react-native";
 import { CenterDecorator } from "../decorators";
-import {
-  ValidityBanner,
-  CheckStatus
-} from "../../../src/components/DocumentRenderer/ValidityBanner";
+import { ValidityBanner } from "../../../src/components/DocumentRenderer/ValidityBanner";
 import { View, Button, Text } from "react-native";
 import { SignedDocument } from "@govtechsg/open-attestation";
-import { checkValidity } from "../../../src/services/DocumentVerifier";
 import sampleDoc from "../../../fixtures/demo-oc.json";
+import { CheckStatus } from "../../../src/constants/verifier";
+import { useDocumentVerifier } from "../../../src/common/hooks/useDocumentVerifier";
 
 const ValidChecksStory: FunctionComponent = () => {
-  const [tamperedCheck, setTamperedCheck] = useState<CheckStatus>("checking");
-  const [issuedCheck, setIssuedCheck] = useState<CheckStatus>("checking");
-  const [revokedCheck, setRevokedCheck] = useState<CheckStatus>("checking");
-  const [issuerCheck, setIssuerCheck] = useState<CheckStatus>("checking");
+  const [tamperedCheck, setTamperedCheck] = useState(CheckStatus.CHECKING);
+  const [issuedCheck, setIssuedCheck] = useState(CheckStatus.CHECKING);
+  const [revokedCheck, setRevokedCheck] = useState(CheckStatus.CHECKING);
+  const [issuerCheck, setIssuerCheck] = useState(CheckStatus.CHECKING);
+  const [overallValidity, setOverallValidity] = useState(CheckStatus.CHECKING);
 
   const [progress, setProgress] = useState<"stopped" | "started">("stopped");
   const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
@@ -22,31 +21,37 @@ const ValidChecksStory: FunctionComponent = () => {
   const start = (): void => {
     timers.current.push(
       setTimeout(() => {
-        setTamperedCheck("valid");
+        setTamperedCheck(CheckStatus.VALID);
       }, 1000)
     );
     timers.current.push(
       setTimeout(() => {
-        setIssuedCheck("valid");
+        setIssuedCheck(CheckStatus.VALID);
       }, 2300)
     );
     timers.current.push(
       setTimeout(() => {
-        setRevokedCheck("valid");
+        setRevokedCheck(CheckStatus.VALID);
       }, 1500)
     );
     timers.current.push(
       setTimeout(() => {
-        setIssuerCheck("valid");
+        setIssuerCheck(CheckStatus.VALID);
+      }, 2600)
+    );
+    timers.current.push(
+      setTimeout(() => {
+        setOverallValidity(CheckStatus.VALID);
       }, 2600)
     );
   };
 
   const reset = (): void => {
-    setTamperedCheck("checking");
-    setIssuedCheck("checking");
-    setRevokedCheck("checking");
-    setIssuerCheck("checking");
+    setTamperedCheck(CheckStatus.CHECKING);
+    setIssuedCheck(CheckStatus.CHECKING);
+    setRevokedCheck(CheckStatus.CHECKING);
+    setIssuerCheck(CheckStatus.CHECKING);
+    setOverallValidity(CheckStatus.CHECKING);
   };
 
   useEffect(() => {
@@ -70,6 +75,7 @@ const ValidChecksStory: FunctionComponent = () => {
         issuedCheck={issuedCheck}
         revokedCheck={revokedCheck}
         issuerCheck={issuerCheck}
+        overallValidity={overallValidity}
       />
       <View
         style={{
@@ -89,10 +95,11 @@ const ValidChecksStory: FunctionComponent = () => {
 };
 
 const InvalidChecksStory: FunctionComponent = () => {
-  const [tamperedCheck, setTamperedCheck] = useState<CheckStatus>("checking");
-  const [issuedCheck, setIssuedCheck] = useState<CheckStatus>("checking");
-  const [revokedCheck, setRevokedCheck] = useState<CheckStatus>("checking");
-  const [issuerCheck, setIssuerCheck] = useState<CheckStatus>("checking");
+  const [tamperedCheck, setTamperedCheck] = useState(CheckStatus.CHECKING);
+  const [issuedCheck, setIssuedCheck] = useState(CheckStatus.CHECKING);
+  const [revokedCheck, setRevokedCheck] = useState(CheckStatus.CHECKING);
+  const [issuerCheck, setIssuerCheck] = useState(CheckStatus.CHECKING);
+  const [overallValidity, setOverallValidity] = useState(CheckStatus.CHECKING);
 
   const [progress, setProgress] = useState<"stopped" | "started">("stopped");
   const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
@@ -100,31 +107,37 @@ const InvalidChecksStory: FunctionComponent = () => {
   const start = (): void => {
     timers.current.push(
       setTimeout(() => {
-        setTamperedCheck("valid");
+        setTamperedCheck(CheckStatus.VALID);
       }, 1000)
     );
     timers.current.push(
       setTimeout(() => {
-        setIssuedCheck("invalid");
+        setIssuedCheck(CheckStatus.INVALID);
       }, 2600)
     );
     timers.current.push(
       setTimeout(() => {
-        setRevokedCheck("invalid");
+        setRevokedCheck(CheckStatus.INVALID);
       }, 2300)
     );
     timers.current.push(
       setTimeout(() => {
-        setIssuerCheck("valid");
+        setIssuerCheck(CheckStatus.VALID);
       }, 1500)
+    );
+    timers.current.push(
+      setTimeout(() => {
+        setOverallValidity(CheckStatus.INVALID);
+      }, 2600)
     );
   };
 
   const reset = (): void => {
-    setTamperedCheck("checking");
-    setIssuedCheck("checking");
-    setRevokedCheck("checking");
-    setIssuerCheck("checking");
+    setTamperedCheck(CheckStatus.CHECKING);
+    setIssuedCheck(CheckStatus.CHECKING);
+    setRevokedCheck(CheckStatus.CHECKING);
+    setIssuerCheck(CheckStatus.CHECKING);
+    setOverallValidity(CheckStatus.CHECKING);
   };
 
   useEffect(() => {
@@ -148,6 +161,7 @@ const InvalidChecksStory: FunctionComponent = () => {
         issuedCheck={issuedCheck}
         revokedCheck={revokedCheck}
         issuerCheck={issuerCheck}
+        overallValidity={overallValidity}
       />
       <View
         style={{
@@ -167,33 +181,13 @@ const InvalidChecksStory: FunctionComponent = () => {
 };
 
 const ActualChecksStory: FunctionComponent = () => {
-  const [tamperedCheck, setTamperedCheck] = useState<CheckStatus>("checking");
-  const [issuedCheck, setIssuedCheck] = useState<CheckStatus>("checking");
-  const [revokedCheck, setRevokedCheck] = useState<CheckStatus>("checking");
-  const [issuerCheck, setIssuerCheck] = useState<CheckStatus>("checking");
-
-  const start = (): void => {
-    const [verifyHashIssuedRevoked, verifyIdentity] = checkValidity(
-      sampleDoc as SignedDocument
-    );
-
-    verifyHashIssuedRevoked.then(v => {
-      setTamperedCheck(v.hash.checksumMatch ? "valid" : "invalid");
-      setIssuedCheck(v.issued.issuedOnAll ? "valid" : "invalid");
-      setRevokedCheck(v.revoked.revokedOnAny ? "invalid" : "valid");
-    });
-
-    verifyIdentity.then(v => {
-      setIssuerCheck(v.identifiedOnAll ? "valid" : "invalid");
-    });
-  };
-
-  const reset = (): void => {
-    setTamperedCheck("checking");
-    setIssuedCheck("checking");
-    setRevokedCheck("checking");
-    setIssuerCheck("checking");
-  };
+  const {
+    tamperedCheck,
+    issuedCheck,
+    revokedCheck,
+    issuerCheck,
+    overallValidity
+  } = useDocumentVerifier(sampleDoc as SignedDocument);
 
   return (
     <View style={{ width: "100%" }}>
@@ -202,19 +196,8 @@ const ActualChecksStory: FunctionComponent = () => {
         issuedCheck={issuedCheck}
         revokedCheck={revokedCheck}
         issuerCheck={issuerCheck}
+        overallValidity={overallValidity}
       />
-      <View
-        style={{
-          flexDirection: "row",
-          marginTop: 8,
-          justifyContent: "space-between",
-          alignSelf: "center",
-          width: "40%"
-        }}
-      >
-        <Button title="Start" onPress={start} />
-        <Button title="Reset" onPress={reset} />
-      </View>
     </View>
   );
 };
@@ -229,28 +212,32 @@ storiesOf("ValidityBanner", module)
       }}
     >
       <ValidityBanner
-        tamperedCheck="checking"
-        issuedCheck="checking"
-        revokedCheck="checking"
-        issuerCheck="checking"
+        tamperedCheck={CheckStatus.CHECKING}
+        issuedCheck={CheckStatus.CHECKING}
+        revokedCheck={CheckStatus.CHECKING}
+        issuerCheck={CheckStatus.CHECKING}
+        overallValidity={CheckStatus.CHECKING}
       />
       <ValidityBanner
-        tamperedCheck="checking"
-        issuedCheck="checking"
-        revokedCheck="checking"
-        issuerCheck="valid"
+        tamperedCheck={CheckStatus.CHECKING}
+        issuedCheck={CheckStatus.CHECKING}
+        revokedCheck={CheckStatus.CHECKING}
+        issuerCheck={CheckStatus.VALID}
+        overallValidity={CheckStatus.CHECKING}
       />
       <ValidityBanner
-        tamperedCheck="invalid"
-        issuedCheck="checking"
-        revokedCheck="checking"
-        issuerCheck="valid"
+        tamperedCheck={CheckStatus.INVALID}
+        issuedCheck={CheckStatus.CHECKING}
+        revokedCheck={CheckStatus.CHECKING}
+        issuerCheck={CheckStatus.VALID}
+        overallValidity={CheckStatus.INVALID}
       />
       <ValidityBanner
-        tamperedCheck="valid"
-        issuedCheck="valid"
-        revokedCheck="valid"
-        issuerCheck="valid"
+        tamperedCheck={CheckStatus.VALID}
+        issuedCheck={CheckStatus.VALID}
+        revokedCheck={CheckStatus.VALID}
+        issuerCheck={CheckStatus.VALID}
+        overallValidity={CheckStatus.VALID}
       />
     </View>
   ));


### PR DESCRIPTION
Also added a helper `tuple` function which allows us to force TS to type an array as a tuple
```
// Ensures TS infers the type of the array as a tuple instead
// https://github.com/Microsoft/TypeScript/pull/24897
function tuple<T extends any[]>(...data: T): T {
  return data;
}
```