### PR TITLE
fix: disable QR camera

### DIFF
--- a/__mocks__/expo-camera.tsx
+++ b/__mocks__/expo-camera.tsx
@@ -6,6 +6,13 @@ import React, {
 } from "react";
 import { View } from "react-native";
 
+/**
+ * A functional component is used so that we can call onCameraReady
+ * only when the ref has initialized (useLayoutEffect).
+ * By using `useImperativeHandle`, we can specify the methods belonging
+ * to the ref.
+ */
+
 // eslint-disable-next-line react/display-name
 export const Camera = forwardRef<View, { onCameraReady?: () => void }>(
   ({ onCameraReady, ...props }, ref: Ref<any>) => {

--- a/__mocks__/expo-camera.tsx
+++ b/__mocks__/expo-camera.tsx
@@ -1,7 +1,22 @@
-import React, { forwardRef, Ref } from "react";
+import React, {
+  forwardRef,
+  Ref,
+  useImperativeHandle,
+  useLayoutEffect
+} from "react";
 import { View } from "react-native";
 
 // eslint-disable-next-line react/display-name
-export const Camera = forwardRef((_, ref: Ref<View>) => (
-  <View testID="qr-camera" ref={ref}></View>
-));
+export const Camera = forwardRef<View, { onCameraReady?: () => void }>(
+  ({ onCameraReady, ...props }, ref: Ref<any>) => {
+    useImperativeHandle(ref, () => ({
+      getSupportedRatiosAsync: () => ["4:3", "16:9"]
+    }));
+
+    useLayoutEffect(() => {
+      onCameraReady?.();
+    }, [onCameraReady]);
+
+    return <View testID="qr-camera" ref={ref} {...props}></View>;
+  }
+);

--- a/__mocks__/expo-camera.tsx
+++ b/__mocks__/expo-camera.tsx
@@ -1,4 +1,7 @@
-import React, { FunctionComponent } from "react";
+import React, { forwardRef, Ref } from "react";
 import { View } from "react-native";
 
-export const Camera: FunctionComponent = () => <View testID="qr-camera"></View>;
+// eslint-disable-next-line react/display-name
+export const Camera = forwardRef((_, ref: Ref<View>) => (
+  <View testID="qr-camera" ref={ref}></View>
+));

--- a/src/components/QrScanner/QrCamera.test.tsx
+++ b/src/components/QrScanner/QrCamera.test.tsx
@@ -4,17 +4,25 @@ import { QrCamera } from "./QrCamera";
 import * as Permissions from "expo-permissions";
 
 const mockPermissions = Permissions.askAsync as jest.Mock;
+
 jest.mock("expo-permissions", () => ({
   askAsync: jest.fn()
 }));
 
+const mockPlatform = (platform: "android" | "ios"): void => {
+  jest.resetModules();
+  jest.doMock("Platform", () => ({ OS: platform, select: jest.fn() }));
+};
+
 describe("QrCamera", () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     mockPermissions.mockReset();
   });
 
   it("should render LoadingView if the camera is disabled", async () => {
     expect.assertions(2);
+    mockPlatform("android");
     mockPermissions.mockResolvedValue({ status: "granted" });
     const { queryByTestId } = render(
       <QrCamera onQrData={() => {}} disabled={true} />
@@ -25,6 +33,7 @@ describe("QrCamera", () => {
 
   it("should render Camera if the camera is enabled", async () => {
     expect.assertions(2);
+    mockPlatform("android");
     mockPermissions.mockReturnValue({ status: "granted" });
     const { queryByTestId } = render(
       <QrCamera onQrData={() => {}} disabled={false} />
@@ -35,6 +44,7 @@ describe("QrCamera", () => {
 
   it("should not render if camera permission is not given", async () => {
     expect.assertions(3);
+    mockPlatform("android");
     mockPermissions.mockReturnValue({ status: "nil" });
     const { queryByTestId } = render(
       <QrCamera onQrData={() => {}} disabled={false} />
@@ -42,5 +52,29 @@ describe("QrCamera", () => {
     expect(queryByTestId("loading-view")).toBeNull();
     await wait(() => expect(queryByTestId("qr-camera")).toBeNull());
     await wait(() => expect(queryByTestId("loading-view")).toBeNull());
+  });
+
+  it("should set the ratio of the camera if on Android", async () => {
+    expect.assertions(1);
+    mockPlatform("android");
+    mockPermissions.mockReturnValue({ status: "granted" });
+    const { queryByTestId } = render(
+      <QrCamera onQrData={() => {}} disabled={false} />
+    );
+    await wait(() => {
+      expect(queryByTestId("qr-camera")?.props).toHaveProperty("ratio", "16:9");
+    });
+  });
+
+  it("should not set the ratio of the camera if on iOS", async () => {
+    expect.assertions(1);
+    mockPlatform("ios");
+    mockPermissions.mockReturnValue({ status: "granted" });
+    const { queryByTestId } = render(
+      <QrCamera onQrData={() => {}} disabled={false} />
+    );
+    await wait(() => {
+      expect(queryByTestId("qr-camera")?.props).not.toHaveProperty("ratio");
+    });
   });
 });

--- a/src/components/QrScanner/QrCamera.test.tsx
+++ b/src/components/QrScanner/QrCamera.test.tsx
@@ -7,7 +7,6 @@ const mockPermissions = Permissions.askAsync as jest.Mock;
 jest.mock("expo-permissions", () => ({
   askAsync: jest.fn()
 }));
-jest.mock("expo-camera");
 
 describe("QrCamera", () => {
   beforeEach(() => {

--- a/src/components/QrScanner/QrCamera.test.tsx
+++ b/src/components/QrScanner/QrCamera.test.tsx
@@ -13,6 +13,7 @@ describe("QrCamera", () => {
   beforeEach(() => {
     mockPermissions.mockReset();
   });
+
   it("should render LoadingView if the camera is disabled", async () => {
     expect.assertions(2);
     mockPermissions.mockResolvedValue({ status: "granted" });
@@ -22,6 +23,7 @@ describe("QrCamera", () => {
     expect(queryByTestId("qr-camera")).toBeNull();
     await wait(() => expect(queryByTestId("loading-view")).not.toBeNull());
   });
+
   it("should render Camera if the camera is enabled", async () => {
     expect.assertions(2);
     mockPermissions.mockReturnValue({ status: "granted" });
@@ -31,6 +33,7 @@ describe("QrCamera", () => {
     expect(queryByTestId("loading-view")).toBeNull();
     await wait(() => expect(queryByTestId("qr-camera")).not.toBeNull());
   });
+
   it("should not render if camera permission is not given", async () => {
     expect.assertions(3);
     mockPermissions.mockReturnValue({ status: "nil" });

--- a/src/components/QrScanner/QrCamera.tsx
+++ b/src/components/QrScanner/QrCamera.tsx
@@ -12,11 +12,13 @@ interface BarCodeScanningResult {
 export interface QrCamera {
   onQrData: (data: string) => void;
   disabled?: boolean;
+  ratio?: string;
 }
 
 export const QrCamera: FunctionComponent<QrCamera> = ({
   onQrData,
-  disabled
+  disabled = false,
+  ratio = "16:9"
 }) => {
   const [hasCameraPermission, setHasCameraPermission] = useState(false);
   const askForCameraPermission = async (): Promise<void> => {
@@ -41,6 +43,7 @@ export const QrCamera: FunctionComponent<QrCamera> = ({
         <Camera
           style={{ flex: 1 }}
           onBarCodeScanned={onBarCodeScanned}
+          ratio={ratio}
           testID="qr-camera"
         />
       )}

--- a/src/components/QrScanner/QrCamera.tsx
+++ b/src/components/QrScanner/QrCamera.tsx
@@ -33,7 +33,7 @@ export const QrCamera: FunctionComponent<QrCamera> = ({
   }, []);
 
   const cameraRef = useRef<Camera>(null);
-  const [ratio, setRatio] = useState("");
+  const [ratio, setRatio] = useState();
   const onCameraReady = async (): Promise<void> => {
     if (Platform.OS === "android" && cameraRef.current) {
       const ratios = await cameraRef.current.getSupportedRatiosAsync();

--- a/src/components/QrScanner/QrScannerScreenContainer.test.tsx
+++ b/src/components/QrScanner/QrScannerScreenContainer.test.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { mockNavigation } from "../../test/helpers/navigation";
+import { QrScannerScreenContainer } from "./QrScannerScreenContainer";
+import { render, wait } from "@testing-library/react-native";
+import { QrCamera } from "./QrCamera";
+
+import { processQr } from "../../services/QrProcessor";
+jest.mock("../../services/QrProcessor");
+const mockProcessQr = processQr as jest.Mock;
+
+import * as Permissions from "expo-permissions";
+jest.mock("expo-permissions", () => ({
+  askAsync: jest.fn()
+}));
+const mockPermissions = Permissions.askAsync as jest.Mock;
+mockPermissions.mockResolvedValue({ status: "granted" });
+
+jest.mock("../../common/navigation");
+
+let cameraProps: QrCamera;
+jest.mock("./QrCamera", () => ({
+  QrCamera: (props: QrCamera) => {
+    cameraProps = { ...props };
+    return null;
+  }
+}));
+
+jest.useFakeTimers();
+
+describe("QrScannerScreenContainer", () => {
+  beforeEach(() => {
+    mockProcessQr.mockReset();
+  });
+
+  it("should disable scanning when camera has encountered a QR code", async () => {
+    expect.assertions(2);
+    render(<QrScannerScreenContainer navigation={mockNavigation} />);
+
+    await wait(() => {
+      expect(cameraProps.disabled).toBe(false);
+      cameraProps.onQrData("data1");
+      expect(cameraProps.disabled).toBe(true);
+    });
+  });
+
+  it("should not process additional QR data when scanning is disabled", async () => {
+    expect.assertions(3);
+    // Mimic slow processing of QR
+    mockProcessQr.mockImplementation(
+      () =>
+        new Promise(res =>
+          setTimeout(() => {
+            res(true);
+          }, 1000)
+        )
+    );
+    render(<QrScannerScreenContainer navigation={mockNavigation} />);
+
+    await wait(() => {
+      cameraProps.onQrData("data1");
+      expect(cameraProps.disabled).toBe(true);
+      expect(mockProcessQr).toHaveBeenCalledTimes(1);
+
+      cameraProps.onQrData("data2");
+      expect(mockProcessQr).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("should navigate when QR processing succeeds", async () => {
+    expect.assertions(3);
+    mockProcessQr.mockImplementation((_, { onDocumentView }) => {
+      onDocumentView();
+    });
+
+    render(<QrScannerScreenContainer navigation={mockNavigation} />);
+
+    await wait(() => {
+      cameraProps.onQrData("data1");
+      expect(cameraProps.disabled).toBe(true);
+      expect(mockProcessQr).toHaveBeenCalledTimes(1);
+      expect(mockNavigation.navigate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("should re-enable scanning when QR processing fails", async () => {
+    expect.assertions(2);
+    mockProcessQr.mockImplementation(() => {
+      throw new Error();
+    });
+
+    render(<QrScannerScreenContainer navigation={mockNavigation} />);
+
+    await wait(() => {
+      cameraProps.onQrData("data1");
+      expect(mockProcessQr).toHaveBeenCalledTimes(1);
+      expect(cameraProps.disabled).toBe(false);
+    });
+  });
+});

--- a/src/components/QrScanner/QrScannerScreenContainer.tsx
+++ b/src/components/QrScanner/QrScannerScreenContainer.tsx
@@ -32,8 +32,8 @@ export const QrScannerScreenContainer: FunctionComponent<QrScannerScreenContaine
     try {
       await processQr(data, { onDocumentStore, onDocumentView });
     } catch (e) {
-      alert(e);
       setScanningDisabled(false);
+      alert(e);
     }
   };
 

--- a/src/components/QrScanner/QrScannerScreenContainer.tsx
+++ b/src/components/QrScanner/QrScannerScreenContainer.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from "react";
+import React, { FunctionComponent, useState, useEffect } from "react";
 import { View } from "react-native";
 import { NavigationProps } from "../../types";
 import { ScreenView } from "../ScreenView";
@@ -25,14 +25,30 @@ export const QrScannerScreenContainer: FunctionComponent<QrScannerScreenContaine
     navigation.navigate("ScannedDocumentScreen", { document });
   };
   const onQrData = async (data: string): Promise<void> => {
+    if (scanningDisabled) {
+      return;
+    }
     setScanningDisabled(true);
     try {
       await processQr(data, { onDocumentStore, onDocumentView });
     } catch (e) {
       alert(e);
+      setScanningDisabled(false);
     }
-    setScanningDisabled(false);
   };
+
+  useEffect(() => {
+    const willBlurSubscription = navigation.addListener("willBlur", () => {
+      setScanningDisabled(true);
+    });
+    const willFocusSubscription = navigation.addListener("willFocus", () => {
+      setScanningDisabled(false);
+    });
+    return () => {
+      willBlurSubscription.remove();
+      willFocusSubscription.remove();
+    };
+  }, [navigation]);
 
   return (
     <ScreenView>

--- a/src/test/helpers/navigation.tsx
+++ b/src/test/helpers/navigation.tsx
@@ -4,7 +4,8 @@ export const mockNavigation: any = {
   navigate: jest.fn(),
   dispatch: jest.fn(),
   goBack: jest.fn(),
-  getParam: (key: string) => params[key]
+  getParam: (key: string) => params[key],
+  addListener: jest.fn()
 };
 
 export const resetNavigation = (): void => {


### PR DESCRIPTION
The QR camera currently keeps scanning even though the user has navigated to the scanned document screen.

Also added `ratio` prop for the camera as the preview was getting stretched on Android.