### PR TITLE
chore: hide yellowbox warning for setting a timer

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,8 @@
 import AppNavigation from "./src/navigation";
 import Storybook from "./storybook";
 import { IS_STORYBOOK_VIEW } from "./src/config";
+import { YellowBox } from "react-native";
+
+YellowBox.ignoreWarnings(["Setting a timer"]);
 
 export default IS_STORYBOOK_VIEW ? Storybook : AppNavigation;


### PR DESCRIPTION
The yellowbox warning won't be shown on android anymore.
Note that the errors will still be logged