### PR TITLE
fix: ensure bottom sheet shows

### DIFF
--- a/src/components/Layout/BottomSheet.tsx
+++ b/src/components/Layout/BottomSheet.tsx
@@ -84,7 +84,10 @@ export const BottomSheet: FunctionComponent<BottomSheet> = ({
   // Snap to the first point whenever snapPoints changes,
   // this allows snapPoints to be dynamic
   useEffect(() => {
-    bottomSheetRef.current && bottomSheetRef.current.snapTo(0);
+    requestAnimationFrame(() => {
+      bottomSheetRef.current && bottomSheetRef.current.snapTo(0);
+    });
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [...snapPoints]);
 


### PR DESCRIPTION
Sometimes the bottom doesn't transition to the dynamically assigned first snap point when we use the bottom sheet's `snapTo` method. This is likely due to that animation frame doing too much (transition into the details view, loading of the webview, etc.) By wrapping in a RAF, this ensures that the `snapTo` is deferred to the next frame.