### PR TITLE
fix: fixed QR protocol to follow the updated ADR

### DIFF
--- a/src/services/QrProcessor/index.tsx
+++ b/src/services/QrProcessor/index.tsx
@@ -7,7 +7,7 @@ import {
 } from "./fetchDocument";
 // The universal transfer method uses the query string's field as the action type
 // and the uriencoded value as the payload
-const universalTransferDataRegex = /https:\/\/openattestation.com\/action\?(.*)=(.*)/;
+const universalTransferDataRegex = /https:\/\/action.openattestation.com\?q=(.*)/;
 
 export enum ActionType {
   DOCUMENT = "DOCUMENT"
@@ -28,14 +28,10 @@ export const decodeAction = (data: string): Action => {
     throw new Error("Invalid QR Protocol");
   }
   try {
-    const actionType = data.match(universalTransferDataRegex)![1].toUpperCase();
-    const encodedPayload = data.match(universalTransferDataRegex)![2];
-    const decodedPayload = JSON.parse(decodeURI(encodedPayload));
-    validateAction(actionType, decodedPayload);
-    return {
-      type: actionType,
-      payload: decodedPayload
-    };
+    const encodedAction = data.match(universalTransferDataRegex)![1];
+    const decodedAction = JSON.parse(decodeURI(encodedAction));
+    validateAction(decodedAction);
+    return decodedAction;
   } catch (e) {
     throw new Error(`Invalid QR Action: ${e.message}`);
   }

--- a/src/services/actionValidator/validator.test.tsx
+++ b/src/services/actionValidator/validator.test.tsx
@@ -4,35 +4,42 @@ describe("validateAction", () => {
   it("should validate document action", () => {
     expect.assertions(1);
     const input = {
-      uri: "https://test.com/doc/123",
-      key: "someverylongkey",
-      permittedActions: ["VIEW"],
-      redirect: "https://tradetrust.io/"
+      type: ActionType.DOCUMENT,
+      payload: {
+        uri: "https://test.com/doc/123",
+        key: "someverylongkey",
+        permittedActions: ["VIEW"],
+        redirect: "https://tradetrust.io/"
+      }
     };
-    expect(() => validateAction(ActionType.DOCUMENT, input)).not.toThrow();
+    expect(() => validateAction(input)).not.toThrow();
   });
 
   it("should throw on invalid document action", () => {
     expect.assertions(1);
     const input = {
-      key: "someverylongkey",
-      permittedActions: ["VIEW"],
-      redirect: "https://tradetrust.io/"
-    };
-    expect(() => validateAction(ActionType.DOCUMENT, input)).toThrow(
-      "uri is a required field"
-    );
+      type: ActionType.DOCUMENT,
+      payload: {
+        key: "someverylongkey",
+        permittedActions: ["VIEW"],
+        redirect: "https://tradetrust.io/"
+      }
+    } as any;
+    expect(() => validateAction(input)).toThrow("uri is a required field");
   });
 
   it("should return validated input", () => {
     expect.assertions(1);
     const input = {
-      uri: "https://test.com/doc/123",
-      key: "someverylongkey",
-      permittedActions: ["VIEW"],
-      redirect: "https://tradetrust.io/"
+      type: ActionType.DOCUMENT,
+      payload: {
+        uri: "https://test.com/doc/123",
+        key: "someverylongkey",
+        permittedActions: ["VIEW"],
+        redirect: "https://tradetrust.io/"
+      }
     };
-    expect(validateAction(ActionType.DOCUMENT, input)).toStrictEqual({
+    expect(validateAction(input)).toStrictEqual({
       uri: "https://test.com/doc/123",
       key: "someverylongkey",
       permittedActions: ["VIEW"],

--- a/src/services/actionValidator/validator.tsx
+++ b/src/services/actionValidator/validator.tsx
@@ -7,7 +7,13 @@ export enum ActionType {
   DOCUMENT = "DOCUMENT"
 }
 
-export const validateAction = (type: string, payload: any): DocumentAction => {
+export const validateAction = ({
+  type,
+  payload
+}: {
+  type: string;
+  payload: any;
+}): DocumentAction => {
   switch (type) {
     case ActionType.DOCUMENT:
       return validateDocumentAction(payload);


### PR DESCRIPTION
Upgraded to use the new convention for QR code

Test with:

`https://action.openattestation.com?q=%7B%22type%22:%22DOCUMENT%22,%22payload%22:%7B%22uri%22:%22https://api.myjson.com/bins/kv1de%22%7D%7D`

![image](https://user-images.githubusercontent.com/7406870/72971509-c2f74e00-3e04-11ea-8d1c-3915a5a79a8d.png)
