### PR TITLE
feat: network selector in settings & useConfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4211,9 +4211,9 @@
       }
     },
     "@types/react-test-renderer": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.1.tgz",
-      "integrity": "sha512-nCXQokZN1jp+QkoDNmDZwoWpKY8HDczqevIDO4Uv9/s9rbGPbSpy8Uaxa5ixHKkcm/Wt0Y9C3wCxZivh4Al+rQ==",
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.2.tgz",
+      "integrity": "sha512-4eJr1JFLIAlWhzDkBCkhrOIWOvOxcCAfQh+jiKg7l/nNZcCIL2MHl2dZhogIFKyHzedVWHaVP1Yydq/Ruu4agw==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -4249,9 +4249,9 @@
       "dev": true
     },
     "@types/testing-library__react-hooks": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.1.0.tgz",
-      "integrity": "sha512-QJc1sgH9DD6jbfybzugnP0sY8wPzzIq8sHDBuThzCr2ZEbyHIaAvN9ytx/tHzcWL5MqmeZJqiUm/GsythaGx3g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.2.0.tgz",
+      "integrity": "sha512-dE8iMTuR5lzB+MqnxlzORlXzXyCL0EKfzH0w/lau20OpkHD37EaWjZDz0iNG8b71iEtxT4XKGmSKAGVEqk46mw==",
       "dev": true,
       "requires": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/jest": "^24.0.24",
     "@types/react": "^16.9.16",
     "@types/react-native": "^0.57.65",
+    "@types/testing-library__react-hooks": "^3.2.0",
     "@types/yup": "^0.26.26",
     "@typescript-eslint/eslint-plugin": "^2.12.0",
     "@typescript-eslint/parser": "^2.12.0",

--- a/src/common/hooks/useConfig/index.tsx
+++ b/src/common/hooks/useConfig/index.tsx
@@ -1,0 +1,46 @@
+import { useState, useEffect } from "react";
+import { AsyncStorage } from "react-native";
+
+export interface Config {
+  network: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/class-name-casing
+export interface useConfig {
+  config: Config;
+  loaded: boolean;
+  setValue: <K extends keyof Config>(key: K, value: Config[K]) => Promise<void>;
+}
+
+const CONFIG_KEY = "CONFIG";
+const DEFAULT_CONFIG = { network: "ropsten" };
+
+export const useConfig = (): useConfig => {
+  const [config, setConfig] = useState<Config>(DEFAULT_CONFIG);
+  const [loaded, setLoaded] = useState(false);
+
+  const setValue: useConfig["setValue"] = async (key, value) => {
+    const nextConfig = {
+      ...config,
+      [key]: value
+    };
+    setConfig(nextConfig);
+    await AsyncStorage.setItem(CONFIG_KEY, JSON.stringify(nextConfig));
+  };
+
+  const loadConfigFromState = async (): Promise<void> => {
+    const configStr = await AsyncStorage.getItem(CONFIG_KEY);
+    if (configStr) {
+      setConfig(JSON.parse(configStr));
+    } else {
+      await AsyncStorage.setItem(CONFIG_KEY, JSON.stringify(DEFAULT_CONFIG));
+    }
+    setLoaded(true);
+  };
+
+  useEffect(() => {
+    loadConfigFromState();
+  }, []);
+
+  return { config, loaded, setValue };
+};

--- a/src/common/hooks/useConfig/index.tsx
+++ b/src/common/hooks/useConfig/index.tsx
@@ -1,25 +1,24 @@
 import { useState, useEffect } from "react";
 import { AsyncStorage } from "react-native";
+import { NetworkTypes } from "../../../types";
 
 export interface Config {
-  network: string;
+  network: NetworkTypes;
 }
-
-// eslint-disable-next-line @typescript-eslint/class-name-casing
-export interface useConfig {
+interface ConfigHook {
   config: Config;
   loaded: boolean;
   setValue: <K extends keyof Config>(key: K, value: Config[K]) => Promise<void>;
 }
 
 const CONFIG_KEY = "CONFIG";
-const DEFAULT_CONFIG = { network: "ropsten" };
+const DEFAULT_CONFIG: Config = { network: NetworkTypes.ropsten };
 
-export const useConfig = (): useConfig => {
-  const [config, setConfig] = useState<Config>(DEFAULT_CONFIG);
+export const useConfig = (): ConfigHook => {
+  const [config, setConfig] = useState(DEFAULT_CONFIG);
   const [loaded, setLoaded] = useState(false);
 
-  const setValue: useConfig["setValue"] = async (key, value) => {
+  const setValue: ConfigHook["setValue"] = async (key, value) => {
     const nextConfig = {
       ...config,
       [key]: value

--- a/src/common/hooks/useConfig/useConfig.test.tsx
+++ b/src/common/hooks/useConfig/useConfig.test.tsx
@@ -22,17 +22,15 @@ describe("useConfig", () => {
   it("should load saved config automatically", async () => {
     expect.assertions(2);
     const { result, waitForNextUpdate } = renderHook(() => useConfig());
-    await act(async () => {
-      await waitForNextUpdate();
-    });
+    await waitForNextUpdate();
     expect(result.current.loaded).toBe(true);
     expect(result.current.config).toStrictEqual({ network: "mainnet" });
   });
   it("should persist updated config", async () => {
     expect.assertions(2);
     const { result, waitForNextUpdate } = renderHook(() => useConfig());
+    await waitForNextUpdate();
     await act(async () => {
-      await waitForNextUpdate();
       await result.current.setValue("network", NetworkTypes.ropsten);
     });
     expect(result.current.config).toStrictEqual({ network: "ropsten" });

--- a/src/common/hooks/useConfig/useConfig.test.tsx
+++ b/src/common/hooks/useConfig/useConfig.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook, act } from "@testing-library/react-hooks";
 import { useConfig } from "./index";
 import { AsyncStorage } from "react-native";
+import { NetworkTypes } from "../../../types";
 
 jest.mock("react-native", () => ({
   AsyncStorage: {
@@ -21,25 +22,23 @@ describe("useConfig", () => {
   it("should load saved config automatically", async () => {
     expect.assertions(2);
     const { result, waitForNextUpdate } = renderHook(() => useConfig());
-
     await act(async () => {
       await waitForNextUpdate();
-      await expect(result.current.loaded).toBe(true);
-      await expect(result.current.config).toStrictEqual({ network: "mainnet" });
     });
+    expect(result.current.loaded).toBe(true);
+    expect(result.current.config).toStrictEqual({ network: "mainnet" });
   });
   it("should persist updated config", async () => {
     expect.assertions(2);
     const { result, waitForNextUpdate } = renderHook(() => useConfig());
-
     await act(async () => {
       await waitForNextUpdate();
-      await result.current.setValue("network", "ropsten");
-      await expect(result.current.config).toStrictEqual({ network: "ropsten" });
-      await expect(mockSetItem).toHaveBeenCalledWith(
-        "CONFIG",
-        JSON.stringify({ network: "ropsten" })
-      );
+      await result.current.setValue("network", NetworkTypes.ropsten);
     });
+    expect(result.current.config).toStrictEqual({ network: "ropsten" });
+    expect(mockSetItem).toHaveBeenCalledWith(
+      "CONFIG",
+      JSON.stringify({ network: "ropsten" })
+    );
   });
 });

--- a/src/common/hooks/useConfig/useConfig.test.tsx
+++ b/src/common/hooks/useConfig/useConfig.test.tsx
@@ -1,0 +1,45 @@
+import { renderHook, act } from "@testing-library/react-hooks";
+import { useConfig } from "./index";
+import { AsyncStorage } from "react-native";
+
+jest.mock("react-native", () => ({
+  AsyncStorage: {
+    setItem: jest.fn(),
+    getItem: jest.fn()
+  }
+}));
+
+const mockGetItem = AsyncStorage.getItem as jest.Mock;
+const mockSetItem = AsyncStorage.setItem as jest.Mock;
+
+describe("useConfig", () => {
+  beforeEach(() => {
+    mockGetItem.mockReset();
+    mockSetItem.mockReset();
+    mockGetItem.mockResolvedValue(JSON.stringify({ network: "mainnet" }));
+  });
+  it("should load saved config automatically", async () => {
+    expect.assertions(2);
+    const { result, waitForNextUpdate } = renderHook(() => useConfig());
+
+    await act(async () => {
+      await waitForNextUpdate();
+      await expect(result.current.loaded).toBe(true);
+      await expect(result.current.config).toStrictEqual({ network: "mainnet" });
+    });
+  });
+  it("should persist updated config", async () => {
+    expect.assertions(2);
+    const { result, waitForNextUpdate } = renderHook(() => useConfig());
+
+    await act(async () => {
+      await waitForNextUpdate();
+      await result.current.setValue("network", "ropsten");
+      await expect(result.current.config).toStrictEqual({ network: "ropsten" });
+      await expect(mockSetItem).toHaveBeenCalledWith(
+        "CONFIG",
+        JSON.stringify({ network: "ropsten" })
+      );
+    });
+  });
+});

--- a/src/common/hooks/useConfig/useConfig.test.tsx
+++ b/src/common/hooks/useConfig/useConfig.test.tsx
@@ -30,8 +30,8 @@ describe("useConfig", () => {
     expect.assertions(2);
     const { result, waitForNextUpdate } = renderHook(() => useConfig());
     await waitForNextUpdate();
-    await act(async () => {
-      await result.current.setValue("network", NetworkTypes.ropsten);
+    act(() => {
+      result.current.setValue("network", NetworkTypes.ropsten);
     });
     expect(result.current.config).toStrictEqual({ network: "ropsten" });
     expect(mockSetItem).toHaveBeenCalledWith(

--- a/src/common/hooks/useDocumentVerifier/index.tsx
+++ b/src/common/hooks/useDocumentVerifier/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { SignedDocument } from "@govtechsg/open-attestation";
 import { CheckStatus } from "../../../components/Validity";
 import { checkValidity } from "../../../services/DocumentVerifier";
+import { useConfig } from "../useConfig";
 
 export interface VerificationStatuses {
   tamperedCheck: CheckStatus;
@@ -14,6 +15,9 @@ export interface VerificationStatuses {
 export const useDocumentVerifier = (
   document: SignedDocument
 ): VerificationStatuses => {
+  const {
+    config: { network }
+  } = useConfig();
   const [tamperedCheck, setTamperedCheck] = useState(CheckStatus.CHECKING);
   const [issuedCheck, setIssuedCheck] = useState(CheckStatus.CHECKING);
   const [revokedCheck, setRevokedCheck] = useState(CheckStatus.CHECKING);
@@ -28,7 +32,7 @@ export const useDocumentVerifier = (
       verifyRevoked,
       verifyIdentity,
       overallValidityCheck
-    ] = checkValidity(document);
+    ] = checkValidity(document, network);
 
     verifyHash.then(
       v =>
@@ -68,7 +72,7 @@ export const useDocumentVerifier = (
     return () => {
       cancelled = true;
     };
-  }, [document]);
+  }, [document, network]);
 
   return {
     tamperedCheck,

--- a/src/common/hooks/useQrGenerator/index.tsx
+++ b/src/common/hooks/useQrGenerator/index.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { uploadDocument } from "../../../services/DocumentSharing";
 import { Document } from "@govtechsg/open-attestation";
 import debounce from "lodash/debounce";
+import { useConfig } from "../useConfig";
 
 const GENERATE_QR_DEBOUNCE_MS = 500;
 
@@ -15,6 +16,9 @@ export interface QrGenerator {
 export const useQrGenerator = (
   initialQrCode: QrCode = { url: "" }
 ): QrGenerator => {
+  const {
+    config: { network }
+  } = useConfig();
   const isMounted = useRef(false);
   const [qrCode, setQrCode] = useState<QrCode>(initialQrCode);
   const [qrCodeLoading, setQrCodeLoading] = useState(false);
@@ -30,7 +34,7 @@ export const useQrGenerator = (
     debounce(async (document: Document) => {
       try {
         setQrCodeLoading(true);
-        const code = await uploadDocument(document);
+        const code = await uploadDocument(document, network);
         if (!isMounted.current) {
           return;
         }

--- a/src/common/hooks/useQrGenerator/useQrGenerator.test.tsx
+++ b/src/common/hooks/useQrGenerator/useQrGenerator.test.tsx
@@ -5,13 +5,17 @@ import { uploadDocument } from "../../../services/DocumentSharing";
 
 jest.mock("../../../services/DocumentSharing");
 jest.mock("lodash/debounce", () => (fn: any) => fn);
+jest.mock("../useConfig", () => ({
+  useConfig: () => ({ config: { network: "mainnet" } })
+}));
 
 const mockUploadDocument = uploadDocument as jest.Mock;
 
 describe("useQrGenerator", () => {
-  it("should have empty qr code that is not loading by default", () => {
+  it("should have empty qr code that is not loading by default", async () => {
     expect.assertions(3);
     const { result } = renderHook(() => useQrGenerator());
+
     expect(result.current.qrCode.url).toBe("");
     expect(result.current.qrCode.expiry).toBeUndefined();
     expect(result.current.qrCodeLoading).toBe(false);
@@ -43,6 +47,18 @@ describe("useQrGenerator", () => {
     expect(result.current.qrCode.url).toBe("QR_CODE");
     expect(result.current.qrCode.expiry).toBe(3);
     expect(result.current.qrCodeLoading).toBe(false);
+  });
+
+  it("should upload document using the correct network", async () => {
+    expect.assertions(1);
+    const { result } = renderHook(() => useQrGenerator());
+    const { generateQr } = result.current;
+    mockUploadDocument.mockResolvedValue("QR_CODE");
+    await act(async () => {
+      await generateQr(sampleDoc);
+    });
+
+    expect(mockUploadDocument.mock.calls[0][1]).toBe("mainnet");
   });
 
   it("should alert errors", async () => {

--- a/src/common/hooks/useQrGenerator/useQrGenerator.test.tsx
+++ b/src/common/hooks/useQrGenerator/useQrGenerator.test.tsx
@@ -12,7 +12,7 @@ jest.mock("../useConfig", () => ({
 const mockUploadDocument = uploadDocument as jest.Mock;
 
 describe("useQrGenerator", () => {
-  it("should have empty qr code that is not loading by default", async () => {
+  it("should have empty qr code that is not loading by default", () => {
     expect.assertions(3);
     const { result } = renderHook(() => useQrGenerator());
 

--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, fireEvent, act } from "@testing-library/react-native";
+import { render, fireEvent } from "@testing-library/react-native";
 import { Settings } from "./Settings";
 import { mockNavigation, resetNavigation } from "../../test/helpers/navigation";
 import { useConfig } from "../../common/hooks/useConfig";
@@ -18,36 +18,30 @@ describe("Settings", () => {
   beforeEach(() => {
     resetNavigation();
   });
-  it("should render the header", async () => {
+  it("should render the header", () => {
     expect.assertions(2);
     const { queryByText, queryByTestId } = render(
       <Settings onResetDocumentData={() => {}} navigation={mockNavigation} />
     );
-    await act(async () => {
-      await expect(queryByText("Settings")).not.toBeNull();
-      await expect(queryByTestId("header-bar")).not.toBeNull();
-    });
+    expect(queryByText("Settings")).not.toBeNull();
+    expect(queryByTestId("header-bar")).not.toBeNull();
   });
-  it("should render the build no", async () => {
+  it("should render the build no", () => {
     expect.assertions(2);
     const { queryByText, queryByTestId } = render(
       <Settings onResetDocumentData={() => {}} navigation={mockNavigation} />
     );
-    await act(async () => {
-      await expect(queryByText("BUILD NO")).not.toBeNull();
-      await expect(queryByTestId("build-no")).not.toBeNull();
-    });
+    expect(queryByText("BUILD NO")).not.toBeNull();
+    expect(queryByTestId("build-no")).not.toBeNull();
   });
-  it("should render the bottom nav", async () => {
+  it("should render the bottom nav", () => {
     expect.assertions(1);
     const { queryByTestId } = render(
       <Settings onResetDocumentData={() => {}} navigation={mockNavigation} />
     );
-    await act(async () => {
-      await expect(queryByTestId("bottom-nav")).not.toBeNull();
-    });
+    expect(queryByTestId("bottom-nav")).not.toBeNull();
   });
-  it("should fire onResetDocumentData when delete is pressed", async () => {
+  it("should fire onResetDocumentData when delete is pressed", () => {
     expect.assertions(1);
     const mockOnResetDocumentData = jest.fn();
     const { getByText } = render(
@@ -57,46 +51,38 @@ describe("Settings", () => {
       />
     );
     fireEvent.press(getByText("Delete"));
-    await act(async () => {
-      await expect(mockOnResetDocumentData).toHaveBeenCalledTimes(1);
-    });
+    expect(mockOnResetDocumentData).toHaveBeenCalledTimes(1);
   });
-  it("should navigate to DocumentListScreen on bottom nav", async () => {
+  it("should navigate to DocumentListScreen on bottom nav", () => {
     expect.assertions(1);
     const { getAllByTestId } = render(
       <Settings onResetDocumentData={() => {}} navigation={mockNavigation} />
     );
     fireEvent.press(getAllByTestId("nav-tab")[0]);
-    await act(async () => {
-      await expect(mockNavigation.dispatch).toHaveBeenCalledWith({
-        routeName: "DocumentListScreen",
-        type: "Navigation/REPLACE"
-      });
+    expect(mockNavigation.dispatch).toHaveBeenCalledWith({
+      routeName: "DocumentListScreen",
+      type: "Navigation/REPLACE"
     });
   });
-  it("should navigate to QrScannerScreen on bottom nav", async () => {
+  it("should navigate to QrScannerScreen on bottom nav", () => {
     expect.assertions(1);
     const { getAllByTestId } = render(
       <Settings onResetDocumentData={() => {}} navigation={mockNavigation} />
     );
     fireEvent.press(getAllByTestId("nav-tab")[1]);
-    await act(async () => {
-      await expect(mockNavigation.dispatch).toHaveBeenCalledWith({
-        routeName: "QrScannerScreen",
-        type: "Navigation/REPLACE"
-      });
+    expect(mockNavigation.dispatch).toHaveBeenCalledWith({
+      routeName: "QrScannerScreen",
+      type: "Navigation/REPLACE"
     });
   });
-  it("should show network from config", async () => {
+  it("should show network from config", () => {
     expect.assertions(1);
     const { queryByText } = render(
       <Settings onResetDocumentData={() => {}} navigation={mockNavigation} />
     );
-    await act(async () => {
-      await expect(queryByText("ROPSTEN")).not.toBeNull();
-    });
+    expect(queryByText("ROPSTEN")).not.toBeNull();
   });
-  it("should toggle network when netowrk toggle is pressed", async () => {
+  it("should toggle network when netowrk toggle is pressed", () => {
     expect.assertions(1);
     const mockOnResetDocumentData = jest.fn();
     const { getByText } = render(
@@ -106,8 +92,6 @@ describe("Settings", () => {
       />
     );
     fireEvent.press(getByText("ROPSTEN"));
-    await act(async () => {
-      await expect(mockSetValue).toHaveBeenCalledWith("network", "mainnet");
-    });
+    expect(mockSetValue).toHaveBeenCalledWith("network", "mainnet");
   });
 });

--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -1,38 +1,53 @@
 import React from "react";
-import { render, fireEvent } from "@testing-library/react-native";
+import { render, fireEvent, act } from "@testing-library/react-native";
 import { Settings } from "./Settings";
 import { mockNavigation, resetNavigation } from "../../test/helpers/navigation";
+import { useConfig } from "../../common/hooks/useConfig";
 
 jest.mock("../../common/navigation");
+jest.mock("../../common/hooks/useConfig");
+
+const mockUseConfig = useConfig as jest.Mock;
+const mockSetValue = jest.fn();
+mockUseConfig.mockReturnValue({
+  config: { network: "ropsten" },
+  setValue: mockSetValue
+});
 
 describe("Settings", () => {
   beforeEach(() => {
     resetNavigation();
   });
-  it("should render the header", () => {
+  it("should render the header", async () => {
     expect.assertions(2);
     const { queryByText, queryByTestId } = render(
       <Settings onResetDocumentData={() => {}} navigation={mockNavigation} />
     );
-    expect(queryByText("Settings")).not.toBeNull();
-    expect(queryByTestId("header-bar")).not.toBeNull();
+    await act(async () => {
+      await expect(queryByText("Settings")).not.toBeNull();
+      await expect(queryByTestId("header-bar")).not.toBeNull();
+    });
   });
-  it("should render the build no", () => {
+  it("should render the build no", async () => {
     expect.assertions(2);
     const { queryByText, queryByTestId } = render(
       <Settings onResetDocumentData={() => {}} navigation={mockNavigation} />
     );
-    expect(queryByText("BUILD NO")).not.toBeNull();
-    expect(queryByTestId("build-no")).not.toBeNull();
+    await act(async () => {
+      await expect(queryByText("BUILD NO")).not.toBeNull();
+      await expect(queryByTestId("build-no")).not.toBeNull();
+    });
   });
-  it("should render the bottom nav", () => {
+  it("should render the bottom nav", async () => {
     expect.assertions(1);
     const { queryByTestId } = render(
       <Settings onResetDocumentData={() => {}} navigation={mockNavigation} />
     );
-    expect(queryByTestId("bottom-nav")).not.toBeNull();
+    await act(async () => {
+      await expect(queryByTestId("bottom-nav")).not.toBeNull();
+    });
   });
-  it("should fire onResetDocumentData when delete is pressed", () => {
+  it("should fire onResetDocumentData when delete is pressed", async () => {
     expect.assertions(1);
     const mockOnResetDocumentData = jest.fn();
     const { getByText } = render(
@@ -42,28 +57,57 @@ describe("Settings", () => {
       />
     );
     fireEvent.press(getByText("Delete"));
-    expect(mockOnResetDocumentData).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await expect(mockOnResetDocumentData).toHaveBeenCalledTimes(1);
+    });
   });
-  it("should navigate to DocumentListScreen on bottom nav", () => {
+  it("should navigate to DocumentListScreen on bottom nav", async () => {
     expect.assertions(1);
     const { getAllByTestId } = render(
       <Settings onResetDocumentData={() => {}} navigation={mockNavigation} />
     );
     fireEvent.press(getAllByTestId("nav-tab")[0]);
-    expect(mockNavigation.dispatch).toHaveBeenCalledWith({
-      routeName: "DocumentListScreen",
-      type: "Navigation/REPLACE"
+    await act(async () => {
+      await expect(mockNavigation.dispatch).toHaveBeenCalledWith({
+        routeName: "DocumentListScreen",
+        type: "Navigation/REPLACE"
+      });
     });
   });
-  it("should navigate to QrScannerScreen on bottom nav", () => {
+  it("should navigate to QrScannerScreen on bottom nav", async () => {
     expect.assertions(1);
     const { getAllByTestId } = render(
       <Settings onResetDocumentData={() => {}} navigation={mockNavigation} />
     );
     fireEvent.press(getAllByTestId("nav-tab")[1]);
-    expect(mockNavigation.dispatch).toHaveBeenCalledWith({
-      routeName: "QrScannerScreen",
-      type: "Navigation/REPLACE"
+    await act(async () => {
+      await expect(mockNavigation.dispatch).toHaveBeenCalledWith({
+        routeName: "QrScannerScreen",
+        type: "Navigation/REPLACE"
+      });
+    });
+  });
+  it("should show network from config", async () => {
+    expect.assertions(1);
+    const { queryByText } = render(
+      <Settings onResetDocumentData={() => {}} navigation={mockNavigation} />
+    );
+    await act(async () => {
+      await expect(queryByText("ROPSTEN")).not.toBeNull();
+    });
+  });
+  it("should toggle network when netowrk toggle is pressed", async () => {
+    expect.assertions(1);
+    const mockOnResetDocumentData = jest.fn();
+    const { getByText } = render(
+      <Settings
+        onResetDocumentData={mockOnResetDocumentData}
+        navigation={mockNavigation}
+      />
+    );
+    fireEvent.press(getByText("ROPSTEN"));
+    await act(async () => {
+      await expect(mockSetValue).toHaveBeenCalledWith("network", "mainnet");
     });
   });
 });

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -6,7 +6,7 @@ import { BottomNav } from "../Layout/BottomNav";
 import { NavigationProps } from "../../types";
 import { BuildView } from "./BuildView";
 import { fontSize, size } from "../../common/styles";
-
+import { useConfig, Config } from "../../common/hooks/useConfig";
 const styles = StyleSheet.create({
   headerText: {
     fontWeight: "bold",
@@ -41,13 +41,24 @@ export interface Settings extends NavigationProps {
 }
 
 export const SettingsView: FunctionComponent<{
+  config: Config;
   onResetDocumentData: () => void;
-}> = ({ onResetDocumentData }) => {
+  onToggleNetwork: () => void;
+}> = ({ config, onResetDocumentData, onToggleNetwork }) => {
   return (
     <ScrollView style={styles.settingsView}>
       <View style={styles.settingsItem}>
         <Text style={styles.settingsItemDescription}>Delete all documents</Text>
         <DarkButton text="Delete" onPress={onResetDocumentData} />
+      </View>
+      <View style={styles.settingsItem}>
+        <Text style={styles.settingsItemDescription}>
+          Switch verification network
+        </Text>
+        <DarkButton
+          text={config.network.toUpperCase()}
+          onPress={onToggleNetwork}
+        />
       </View>
     </ScrollView>
   );
@@ -57,13 +68,21 @@ export const Settings: FunctionComponent<Settings> = ({
   onResetDocumentData,
   navigation
 }) => {
+  const { config, setValue } = useConfig();
+  const onToggleNetwork = (): void => {
+    setValue("network", config.network == "ropsten" ? "mainnet" : "ropsten");
+  };
   return (
     <>
       <Header>
         <Text style={styles.headerText}>Settings</Text>
       </Header>
       <View style={styles.contentWrapper}>
-        <SettingsView onResetDocumentData={onResetDocumentData} />
+        <SettingsView
+          onResetDocumentData={onResetDocumentData}
+          onToggleNetwork={onToggleNetwork}
+          config={config}
+        />
         <BuildView />
       </View>
       <BottomNav navigation={navigation} />

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -7,6 +7,7 @@ import { NavigationProps } from "../../types";
 import { BuildView } from "./BuildView";
 import { fontSize, size } from "../../common/styles";
 import { useConfig, Config } from "../../common/hooks/useConfig";
+import { NetworkTypes } from "../../types";
 const styles = StyleSheet.create({
   headerText: {
     fontWeight: "bold",
@@ -70,7 +71,12 @@ export const Settings: FunctionComponent<Settings> = ({
 }) => {
   const { config, setValue } = useConfig();
   const onToggleNetwork = (): void => {
-    setValue("network", config.network == "ropsten" ? "mainnet" : "ropsten");
+    setValue(
+      "network",
+      config.network === NetworkTypes.ropsten
+        ? NetworkTypes.mainnet
+        : NetworkTypes.ropsten
+    );
   };
   return (
     <>

--- a/src/config/index.tsx
+++ b/src/config/index.tsx
@@ -6,4 +6,6 @@ export const IS_STORYBOOK_VIEW =
   Constants.manifest?.env?.EXPO_START_STORYBOOK === "true" ||
   (Constants.manifest?.releaseChannel || "").indexOf("storybook") > -1;
 export const BUILD_NO = Constants.manifest.revisionId || "LOCAL";
-export const STORAGE_API_ENDPOINT = "https://api-ropsten.opencerts.io/storage/";
+export const ROPSTEN_STORAGE_API_ENDPOINT =
+  "https://api-ropsten.opencerts.io/storage/";
+export const MAINNET_STORAGE_API_ENDPOINT = "https://api.opencerts.io/storage/";

--- a/src/services/DocumentSharing/DocumentSharing.test.tsx
+++ b/src/services/DocumentSharing/DocumentSharing.test.tsx
@@ -34,7 +34,7 @@ describe("uploadDocument", () => {
       key: "SECRET-KEY",
       ttl: expiry
     });
-    const qrCode = await uploadDocument(document, 30000);
+    const qrCode = await uploadDocument(document, "ropsten", 30000);
     expect(qrCode).toStrictEqual({
       url:
         "https://openattestation.com/action?document=%7B%22uri%22:%22https://api-ropsten.opencerts.io/storage/DOCUMENT-ID%22,%22key%22:%22SECRET-KEY%22%7D",
@@ -46,6 +46,8 @@ describe("uploadDocument", () => {
     expect.assertions(1);
     const document: any = "SAMPLE_DOCUMENT";
     mockJsonResponse.mockRejectedValue(new Error("TEST_ERROR"));
-    await expect(uploadDocument(document)).rejects.toThrow("TEST_ERROR");
+    await expect(uploadDocument(document, "ropsten")).rejects.toThrow(
+      "TEST_ERROR"
+    );
   });
 });

--- a/src/services/DocumentSharing/DocumentSharing.test.tsx
+++ b/src/services/DocumentSharing/DocumentSharing.test.tsx
@@ -1,5 +1,5 @@
 import { uploadDocument } from "./index";
-
+import { NetworkTypes } from "../../types";
 const mockJsonResponse = jest.fn();
 const mockFetch = jest.fn();
 
@@ -34,7 +34,7 @@ describe("uploadDocument", () => {
       key: "SECRET-KEY",
       ttl: expiry
     });
-    const qrCode = await uploadDocument(document, "ropsten", 30000);
+    const qrCode = await uploadDocument(document, NetworkTypes.ropsten, 30000);
     expect(qrCode).toStrictEqual({
       url:
         "https://openattestation.com/action?document=%7B%22uri%22:%22https://api-ropsten.opencerts.io/storage/DOCUMENT-ID%22,%22key%22:%22SECRET-KEY%22%7D",
@@ -46,8 +46,8 @@ describe("uploadDocument", () => {
     expect.assertions(1);
     const document: any = "SAMPLE_DOCUMENT";
     mockJsonResponse.mockRejectedValue(new Error("TEST_ERROR"));
-    await expect(uploadDocument(document, "ropsten")).rejects.toThrow(
-      "TEST_ERROR"
-    );
+    await expect(
+      uploadDocument(document, NetworkTypes.ropsten)
+    ).rejects.toThrow("TEST_ERROR");
   });
 });

--- a/src/services/DocumentSharing/index.tsx
+++ b/src/services/DocumentSharing/index.tsx
@@ -3,6 +3,7 @@ import {
   ROPSTEN_STORAGE_API_ENDPOINT,
   MAINNET_STORAGE_API_ENDPOINT
 } from "../../config";
+import { NetworkTypes } from "../../types";
 
 export interface StorageApiResponse {
   id: string;
@@ -20,11 +21,11 @@ const DEFAULT_TTL_MS = 10 * 60 * 1000;
  */
 export const uploadDocument = async (
   document: Document,
-  network: string,
+  network: NetworkTypes,
   ttl = DEFAULT_TTL_MS
 ): Promise<{ url: string; expiry?: number }> => {
   const endpoint =
-    network === "mainnet"
+    network === NetworkTypes.mainnet
       ? MAINNET_STORAGE_API_ENDPOINT
       : ROPSTEN_STORAGE_API_ENDPOINT;
   const response: StorageApiResponse = await fetch(endpoint, {

--- a/src/services/DocumentSharing/index.tsx
+++ b/src/services/DocumentSharing/index.tsx
@@ -1,10 +1,14 @@
 import { Document } from "@govtechsg/open-attestation";
-import { STORAGE_API_ENDPOINT } from "../../config";
+import {
+  ROPSTEN_STORAGE_API_ENDPOINT,
+  MAINNET_STORAGE_API_ENDPOINT
+} from "../../config";
 
 export interface StorageApiResponse {
   id: string;
   key: string;
   ttl?: number;
+  error?: string;
 }
 
 const DEFAULT_TTL_MS = 10 * 60 * 1000;
@@ -16,18 +20,24 @@ const DEFAULT_TTL_MS = 10 * 60 * 1000;
  */
 export const uploadDocument = async (
   document: Document,
+  network: string,
   ttl = DEFAULT_TTL_MS
 ): Promise<{ url: string; expiry?: number }> => {
-  const response: StorageApiResponse = await fetch(STORAGE_API_ENDPOINT, {
+  const endpoint =
+    network === "mainnet"
+      ? MAINNET_STORAGE_API_ENDPOINT
+      : ROPSTEN_STORAGE_API_ENDPOINT;
+  const response: StorageApiResponse = await fetch(endpoint, {
     method: "POST",
     body: JSON.stringify({
       document,
       ttl
     })
   }).then(res => res.json());
+  if (response.error) throw new Error(response.error);
   const payload = encodeURI(
     JSON.stringify({
-      uri: `${STORAGE_API_ENDPOINT}${response.id}`,
+      uri: `${endpoint}${response.id}`,
       key: response.key
     })
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,3 +27,8 @@ export type DatabaseCollections = {
   documents: RxCollection<DocumentProperties>;
 };
 export type Database = RxDatabase<DatabaseCollections>;
+
+export enum NetworkTypes {
+  ropsten = "ropsten",
+  mainnet = "mainnet"
+}


### PR DESCRIPTION
Done:
- Fixed error with `uploadDocument` that does not throw when the server returns 400 with error
- Added `useConfig` for any component to access and modify the config saved on the phone directly
- Added button to switch network in settings

To be done:
- Async storage is now deprecated in `react-native` package but expo has not updated to use the community version. Issue created #55