### PR TITLE
fix: minimum height of iframe

### DIFF
--- a/src/components/DocumentRenderer/WebViewFrame.tsx
+++ b/src/components/DocumentRenderer/WebViewFrame.tsx
@@ -64,9 +64,14 @@ export const WebViewFrame: FunctionComponent<WebViewFrame> = ({
           const templates = window.openAttestation({type: "GET_TEMPLATES", payload: documentToRender});
           window.ReactNativeWebView.postMessage(JSON.stringify(templates));
 
-          // Add spacing container to the bottom of the document so that it isn't blocked by the bottom sheet
+          // Add spacing container to ensure the document isn't blocked by the bottom sheet
           const spacingContainer = document.createElement('div');
-          spacingContainer.style.height = '30vh';
+          spacingContainer.style.position = 'absolute';
+          spacingContainer.style.top = 0;
+          spacingContainer.style.left = 0;
+          spacingContainer.style.right = 0;
+          spacingContainer.style.zIndex = -99;
+          spacingContainer.style.height = '140vh';
           document.body.appendChild(spacingContainer);
         `}
       onMessage={onTemplateMessageHandler}

--- a/src/components/DocumentRenderer/WebViewFrame.tsx
+++ b/src/components/DocumentRenderer/WebViewFrame.tsx
@@ -65,13 +65,13 @@ export const WebViewFrame: FunctionComponent<WebViewFrame> = ({
           window.ReactNativeWebView.postMessage(JSON.stringify(templates));
 
           // Add spacing container to ensure the document isn't blocked by the bottom sheet
-          const spacingContainer = document.createElement('div');
-          spacingContainer.style.position = 'absolute';
+          const spacingContainer = document.createElement("div");
+          spacingContainer.style.position = "absolute";
           spacingContainer.style.top = 0;
           spacingContainer.style.left = 0;
           spacingContainer.style.right = 0;
           spacingContainer.style.zIndex = -99;
-          spacingContainer.style.height = '140vh';
+          spacingContainer.style.height = "140vh";
           document.body.appendChild(spacingContainer);
         `}
       onMessage={onTemplateMessageHandler}

--- a/src/components/DocumentRenderer/WebViewFrame.tsx
+++ b/src/components/DocumentRenderer/WebViewFrame.tsx
@@ -72,6 +72,7 @@ export const WebViewFrame: FunctionComponent<WebViewFrame> = ({
           spacingContainer.style.right = 0;
           spacingContainer.style.zIndex = -99;
           spacingContainer.style.height = "140vh";
+          spacingContainer.style.pointerEvents = "none";
           document.body.appendChild(spacingContainer);
         `}
       onMessage={onTemplateMessageHandler}


### PR DESCRIPTION
Tried several approaches to ensure the bottom sheet doesn't block the renderer, this approach looks to be the cleanest.

**1. Add a third snap point for the bottom sheet** 
This hides as much of the bottom sheet as possible. However, the bottom sheet library doesn't provide the necessarily callbacks to figure out which snap point is currently activated. So we cannot tell if the sheet is opened or not. Events such as `onCloseEnd` refer to when the bottom sheet is entirely closed or opened (i.e. at the first or last snap point)

**2. Resize the webview as the user drags the bottom sheet**
Got this to partially work by passing the height of the bottom sheet back up to the local document renderer which stores the state of this. But there's visible lag as the state of the height is updated.

---

This approach therefore just relies on making a sufficiently large spacing container within the body of the iframe. There's a small edge case on very small devices where the height of the document is larger than 140vh. In this case, the bottom sheet will block the document.

Given that this issue is likely to occur on small group of users (probably need some analytics to find out), it's an enhancement that we can address in future.