### PR TITLE
feat: run in web

### DIFF
--- a/assets/icons/qr.svg
+++ b/assets/icons/qr.svg
@@ -1,64 +1,70 @@
-<svg width="11" height="11" viewBox="0 0 11 11" fill="#4F4F4F" xmlns="http://www.w3.org/2000/svg">
-<rect width="1" height="1" />
-<rect x="2" width="1" height="1"/>
-<rect x="1" width="1" height="1"/>
-<rect y="2" width="1" height="1"/>
-<rect x="2" y="2" width="1" height="1"/>
-<rect x="2" y="1" width="1" height="1"/>
-<rect y="1" width="1" height="1"/>
-<rect x="1" y="2" width="1" height="1"/>
-<rect x="8" width="1" height="1"/>
-<rect x="10" width="1" height="1"/>
-<rect x="9" width="1" height="1"/>
-<rect x="8" y="2" width="1" height="1"/>
-<rect x="10" y="2" width="1" height="1"/>
-<rect x="10" y="10" width="1" height="1"/>
-<rect x="7" y="10" width="1" height="1"/>
-<rect x="4" y="1" width="1" height="1"/>
-<rect x="4" y="2" width="1" height="1"/>
-<rect x="5" width="1" height="1"/>
-<rect x="4" width="1" height="1"/>
-<rect x="6" y="1" width="1" height="1"/>
-<rect x="4" y="3" width="1" height="1"/>
-<rect x="4" y="5" width="1" height="1"/>
-<rect x="2" y="4" width="1" height="1"/>
-<rect x="1" y="4" width="1" height="1"/>
-<rect y="5" width="1" height="1"/>
-<rect x="2" y="6" width="1" height="1"/>
-<rect y="6" width="1" height="1"/>
-<rect x="6" y="2" width="1" height="1"/>
-<rect x="8" y="5" width="1" height="1"/>
-<rect x="10" y="5" width="1" height="1"/>
-<rect x="7" y="3" width="1" height="1"/>
-<rect x="6" y="10" width="1" height="1"/>
-<rect x="4" y="10" width="1" height="1"/>
-<rect x="9" y="10" width="1" height="1"/>
-<rect x="10" y="1" width="1" height="1"/>
-<rect x="8" y="1" width="1" height="1"/>
-<rect x="9" y="2" width="1" height="1"/>
-<rect x="9" y="5" width="1" height="1"/>
-<rect x="8" y="7" width="1" height="1"/>
-<rect x="8" y="8" width="1" height="1"/>
-<rect x="10" y="8" width="1" height="1"/>
-<rect x="10" y="7" width="1" height="1"/>
-<rect x="10" y="6" width="1" height="1"/>
-<rect x="8" y="6" width="1" height="1"/>
-<rect x="9" y="7" width="1" height="1"/>
-<rect x="6" y="5" width="1" height="1"/>
-<rect x="5" y="5" width="1" height="1"/>
-<rect x="4" y="7" width="1" height="1"/>
-<rect x="4" y="8" width="1" height="1"/>
-<rect x="6" y="8" width="1" height="1"/>
-<rect x="6" y="7" width="1" height="1"/>
-<rect x="6" y="6" width="1" height="1"/>
-<rect x="4" y="6" width="1" height="1"/>
-<rect x="5" y="8" width="1" height="1"/>
-<rect y="8" width="1" height="1"/>
-<rect x="2" y="8" width="1" height="1"/>
-<rect x="1" y="8" width="1" height="1"/>
-<rect y="10" width="1" height="1"/>
-<rect x="2" y="10" width="1" height="1"/>
-<rect x="2" y="9" width="1" height="1"/>
-<rect y="9" width="1" height="1"/>
-<rect x="1" y="10" width="1" height="1"/>
-</svg>
+  <svg
+    width="11"
+    height="11"
+    viewBox="0 0 11 11"
+    fill="#4F4F4F"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect width="1" height="1" />
+    <rect x="2" width="1" height="1" />
+    <rect x="1" width="1" height="1" />
+    <rect y="2" width="1" height="1" />
+    <rect x="2" y="2" width="1" height="1" />
+    <rect x="2" y="1" width="1" height="1" />
+    <rect y="1" width="1" height="1" />
+    <rect x="1" y="2" width="1" height="1" />
+    <rect x="8" width="1" height="1" />
+    <rect x="10" width="1" height="1" />
+    <rect x="9" width="1" height="1" />
+    <rect x="8" y="2" width="1" height="1" />
+    <rect x="10" y="2" width="1" height="1" />
+    <rect x="10" y="10" width="1" height="1" />
+    <rect x="7" y="10" width="1" height="1" />
+    <rect x="4" y="1" width="1" height="1" />
+    <rect x="4" y="2" width="1" height="1" />
+    <rect x="5" width="1" height="1" />
+    <rect x="4" width="1" height="1" />
+    <rect x="6" y="1" width="1" height="1" />
+    <rect x="4" y="3" width="1" height="1" />
+    <rect x="4" y="5" width="1" height="1" />
+    <rect x="2" y="4" width="1" height="1" />
+    <rect x="1" y="4" width="1" height="1" />
+    <rect y="5" width="1" height="1" />
+    <rect x="2" y="6" width="1" height="1" />
+    <rect y="6" width="1" height="1" />
+    <rect x="6" y="2" width="1" height="1" />
+    <rect x="8" y="5" width="1" height="1" />
+    <rect x="10" y="5" width="1" height="1" />
+    <rect x="7" y="3" width="1" height="1" />
+    <rect x="6" y="10" width="1" height="1" />
+    <rect x="4" y="10" width="1" height="1" />
+    <rect x="9" y="10" width="1" height="1" />
+    <rect x="10" y="1" width="1" height="1" />
+    <rect x="8" y="1" width="1" height="1" />
+    <rect x="9" y="2" width="1" height="1" />
+    <rect x="9" y="5" width="1" height="1" />
+    <rect x="8" y="7" width="1" height="1" />
+    <rect x="8" y="8" width="1" height="1" />
+    <rect x="10" y="8" width="1" height="1" />
+    <rect x="10" y="7" width="1" height="1" />
+    <rect x="10" y="6" width="1" height="1" />
+    <rect x="8" y="6" width="1" height="1" />
+    <rect x="9" y="7" width="1" height="1" />
+    <rect x="6" y="5" width="1" height="1" />
+    <rect x="5" y="5" width="1" height="1" />
+    <rect x="4" y="7" width="1" height="1" />
+    <rect x="4" y="8" width="1" height="1" />
+    <rect x="6" y="8" width="1" height="1" />
+    <rect x="6" y="7" width="1" height="1" />
+    <rect x="6" y="6" width="1" height="1" />
+    <rect x="4" y="6" width="1" height="1" />
+    <rect x="5" y="8" width="1" height="1" />
+    <rect y="8" width="1" height="1" />
+    <rect x="2" y="8" width="1" height="1" />
+    <rect x="1" y="8" width="1" height="1" />
+    <rect y="10" width="1" height="1" />
+    <rect x="2" y="10" width="1" height="1" />
+    <rect x="2" y="9" width="1" height="1" />
+    <rect y="9" width="1" height="1" />
+    <rect x="1" y="10" width="1" height="1" />
+  </svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14264,6 +14264,103 @@
         "pouchdb-utils": "6.4.3"
       }
     },
+    "pouchdb-adapter-idb": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-idb/-/pouchdb-adapter-idb-7.2.1.tgz",
+      "integrity": "sha512-wr6clFBxehmJdtr9mdl+LE51W572wdA8dm2CN8s2E4jmHgP4juj/kY+XBP2kGStdu20VxL9gF97599VSt1BsOQ==",
+      "requires": {
+        "pouchdb-adapter-utils": "7.2.1",
+        "pouchdb-binary-utils": "7.2.1",
+        "pouchdb-collections": "7.2.1",
+        "pouchdb-errors": "7.2.1",
+        "pouchdb-json": "7.2.1",
+        "pouchdb-merge": "7.2.1",
+        "pouchdb-utils": "7.2.1"
+      },
+      "dependencies": {
+        "buffer-from": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+          "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+        },
+        "immediate": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+          "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+        },
+        "pouchdb-adapter-utils": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/pouchdb-adapter-utils/-/pouchdb-adapter-utils-7.2.1.tgz",
+          "integrity": "sha512-asMAhH6mJRgz6JFEvaS/gMcfWR9pCM+DLPzzIN5vSAm8jUEaMApCONx86xhBwVgzAJ8aVzrG11J9D5iJlM7LSQ==",
+          "requires": {
+            "pouchdb-binary-utils": "7.2.1",
+            "pouchdb-collections": "7.2.1",
+            "pouchdb-errors": "7.2.1",
+            "pouchdb-md5": "7.2.1",
+            "pouchdb-merge": "7.2.1",
+            "pouchdb-utils": "7.2.1"
+          }
+        },
+        "pouchdb-binary-utils": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/pouchdb-binary-utils/-/pouchdb-binary-utils-7.2.1.tgz",
+          "integrity": "sha512-kbzOOYti/3d8s2bQY5EfJVd7c9E84q4oEpr1M8fOOHKnINZFteKkZQywD4roblUnew0Obyhvozif4LAr3CMZFg==",
+          "requires": {
+            "buffer-from": "1.1.0"
+          }
+        },
+        "pouchdb-collections": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-7.2.1.tgz",
+          "integrity": "sha512-cqe3GY3wDq2j59tnh+5ZV0bZj1O+YWiBz4qM7HEcgrEXnc29ADvXXPp71tmcpZUCR39bzLKyYtadAQu7FpOeOA=="
+        },
+        "pouchdb-errors": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-7.2.1.tgz",
+          "integrity": "sha512-/tBP+eWY6a62UoZnJ6JJlNmbNpNS5FgVimkqwLMrFQkXpbJlhshYDeJ5PHR0W3Rlfc54GMZC7m4KhJt9kG/CkA==",
+          "requires": {
+            "inherits": "2.0.4"
+          }
+        },
+        "pouchdb-json": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/pouchdb-json/-/pouchdb-json-7.2.1.tgz",
+          "integrity": "sha512-YGRX/qDl+iEX2vz23kzBtMoH0hpb9xASKnEGZPH76BTDq4RQ+eUOxyXU9E1fPdQhsq8+0pcEQN7VCnFEdQ7MUQ==",
+          "requires": {
+            "vuvuzela": "1.0.3"
+          }
+        },
+        "pouchdb-md5": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/pouchdb-md5/-/pouchdb-md5-7.2.1.tgz",
+          "integrity": "sha512-TJqGtNguctPiSai5b4+oTPi9oOcxSbNolkUtxRBxklf8kw+PNsDUi1H0DIFmA57n0qHCU19PXdbEVYlUhv/PAA==",
+          "requires": {
+            "pouchdb-binary-utils": "7.2.1",
+            "spark-md5": "3.0.0"
+          }
+        },
+        "pouchdb-merge": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/pouchdb-merge/-/pouchdb-merge-7.2.1.tgz",
+          "integrity": "sha512-TgxXPw1sZERwihoWSzLIdvn5MP1YKhYNaB0UuvYjboK+WUpCLh5WEeNTJi6WwUD9Yoc66QxP9D3qmfNEjd1BHQ=="
+        },
+        "pouchdb-utils": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-7.2.1.tgz",
+          "integrity": "sha512-ZInfRpKtJ2HwLz2Dv3NEona9khvGud0rWzvQGwUs1zoaOoSB5XxK3ui5s5fLpBrONgz0WcTB49msOUq4oAUzFg==",
+          "requires": {
+            "argsarray": "0.0.1",
+            "clone-buffer": "1.0.0",
+            "immediate": "3.0.6",
+            "inherits": "2.0.4",
+            "pouchdb-collections": "7.2.1",
+            "pouchdb-errors": "7.2.1",
+            "pouchdb-md5": "7.2.1",
+            "uuid": "3.3.3"
+          }
+        }
+      }
+    },
     "pouchdb-adapter-react-native-sqlite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pouchdb-adapter-react-native-sqlite/-/pouchdb-adapter-react-native-sqlite-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "expo-sqlite": "~7.0.0",
     "humanize-duration": "^3.21.0",
     "lodash": "^4.17.15",
+    "pouchdb-adapter-idb": "^7.2.1",
     "pouchdb-adapter-react-native-sqlite": "^2.0.0",
     "pouchdb-react-native": "^6.4.1",
     "react": "^16.12.0",

--- a/src/assets/qr.tsx
+++ b/src/assets/qr.tsx
@@ -1,0 +1,86 @@
+import React, { ReactElement } from "react";
+
+interface QRWebIconInterface {
+  width: number;
+  height: number;
+  fill?: string;
+}
+
+export const QRWebIcon = ({
+  width,
+  height,
+  fill
+}: QRWebIconInterface): ReactElement => {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 11 11"
+      fill={fill ? fill : "4F4F4F"}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect width="1" height="1" />
+      <rect x="2" width="1" height="1" />
+      <rect x="1" width="1" height="1" />
+      <rect y="2" width="1" height="1" />
+      <rect x="2" y="2" width="1" height="1" />
+      <rect x="2" y="1" width="1" height="1" />
+      <rect y="1" width="1" height="1" />
+      <rect x="1" y="2" width="1" height="1" />
+      <rect x="8" width="1" height="1" />
+      <rect x="10" width="1" height="1" />
+      <rect x="9" width="1" height="1" />
+      <rect x="8" y="2" width="1" height="1" />
+      <rect x="10" y="2" width="1" height="1" />
+      <rect x="10" y="10" width="1" height="1" />
+      <rect x="7" y="10" width="1" height="1" />
+      <rect x="4" y="1" width="1" height="1" />
+      <rect x="4" y="2" width="1" height="1" />
+      <rect x="5" width="1" height="1" />
+      <rect x="4" width="1" height="1" />
+      <rect x="6" y="1" width="1" height="1" />
+      <rect x="4" y="3" width="1" height="1" />
+      <rect x="4" y="5" width="1" height="1" />
+      <rect x="2" y="4" width="1" height="1" />
+      <rect x="1" y="4" width="1" height="1" />
+      <rect y="5" width="1" height="1" />
+      <rect x="2" y="6" width="1" height="1" />
+      <rect y="6" width="1" height="1" />
+      <rect x="6" y="2" width="1" height="1" />
+      <rect x="8" y="5" width="1" height="1" />
+      <rect x="10" y="5" width="1" height="1" />
+      <rect x="7" y="3" width="1" height="1" />
+      <rect x="6" y="10" width="1" height="1" />
+      <rect x="4" y="10" width="1" height="1" />
+      <rect x="9" y="10" width="1" height="1" />
+      <rect x="10" y="1" width="1" height="1" />
+      <rect x="8" y="1" width="1" height="1" />
+      <rect x="9" y="2" width="1" height="1" />
+      <rect x="9" y="5" width="1" height="1" />
+      <rect x="8" y="7" width="1" height="1" />
+      <rect x="8" y="8" width="1" height="1" />
+      <rect x="10" y="8" width="1" height="1" />
+      <rect x="10" y="7" width="1" height="1" />
+      <rect x="10" y="6" width="1" height="1" />
+      <rect x="8" y="6" width="1" height="1" />
+      <rect x="9" y="7" width="1" height="1" />
+      <rect x="6" y="5" width="1" height="1" />
+      <rect x="5" y="5" width="1" height="1" />
+      <rect x="4" y="7" width="1" height="1" />
+      <rect x="4" y="8" width="1" height="1" />
+      <rect x="6" y="8" width="1" height="1" />
+      <rect x="6" y="7" width="1" height="1" />
+      <rect x="6" y="6" width="1" height="1" />
+      <rect x="4" y="6" width="1" height="1" />
+      <rect x="5" y="8" width="1" height="1" />
+      <rect y="8" width="1" height="1" />
+      <rect x="2" y="8" width="1" height="1" />
+      <rect x="1" y="8" width="1" height="1" />
+      <rect y="10" width="1" height="1" />
+      <rect x="2" y="10" width="1" height="1" />
+      <rect x="2" y="9" width="1" height="1" />
+      <rect y="9" width="1" height="1" />
+      <rect x="1" y="10" width="1" height="1" />
+    </svg>
+  );
+};

--- a/src/components/DocumentList/EmptyDocumentList.tsx
+++ b/src/components/DocumentList/EmptyDocumentList.tsx
@@ -1,6 +1,14 @@
 import React, { FunctionComponent } from "react";
-import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  Platform
+} from "react-native";
+import { QRWebIcon } from "../../assets/qr";
 import QRIcon from "../../../assets/icons/qr.svg";
+
 import {
   fontSize,
   color,
@@ -62,7 +70,11 @@ export const EmptyDocumentList: FunctionComponent<EmptyDocumentList> = ({
         style={styles.calloutButton}
         onPress={onAdd}
       >
-        <QRIcon width={20} height={20} fill={color("grey", 40)} />
+        {Platform.OS === "web" ? (
+          <QRWebIcon width={20} height={20} fill={color("grey", 40)} />
+        ) : (
+          <QRIcon width={20} height={20} fill={color("grey", 40)} />
+        )}
         <Text style={styles.calloutButtonText}>Scan to add</Text>
       </TouchableOpacity>
     </View>

--- a/src/components/DocumentRenderer/DocumentDetailsSheet.tsx
+++ b/src/components/DocumentRenderer/DocumentDetailsSheet.tsx
@@ -15,6 +15,7 @@ import {
   Platform
 } from "react-native";
 import { BottomSheet } from "../Layout/BottomSheet";
+import { QRWebIcon } from "../../assets/qr";
 import QRIcon from "../../../assets/icons/qr.svg";
 import { ValidityBanner } from "../Validity/ValidityBanner";
 import { useDocumentVerifier } from "../../common/hooks/useDocumentVerifier";
@@ -187,7 +188,11 @@ const ShareButton: FunctionComponent<ShareButton> = ({
           accessible
           style={{ justifyContent: "center", alignItems: "center" }}
         >
-          <QRIcon width={size(3)} height={size(3)} />
+          {Platform.OS === "web" ? (
+            <QRWebIcon width={size(3)} height={size(3)} />
+          ) : (
+            <QRIcon width={size(3)} height={size(3)} />
+          )}
           <Text style={styles.shareButtonLabel}>Share</Text>
         </View>
       </TouchableOpacity>

--- a/src/components/Initialisation/utils.tsx
+++ b/src/components/Initialisation/utils.tsx
@@ -1,10 +1,16 @@
+import { Platform } from "react-native";
 import { DatabaseCollections } from "../../types";
 import * as RxDB from "rxdb";
 import { DB_CONFIG } from "../../config";
 import * as SQLite from "expo-sqlite";
 import SQLiteAdapterFactory from "pouchdb-adapter-react-native-sqlite";
 
-RxDB.plugin(SQLiteAdapterFactory(SQLite));
+if (Platform.OS === "web") {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  RxDB.plugin(require("pouchdb-adapter-idb"));
+} else {
+  RxDB.plugin(SQLiteAdapterFactory(SQLite));
+}
 
 export const initialiseDb = async ({
   db,

--- a/src/components/Layout/BottomNav.tsx
+++ b/src/components/Layout/BottomNav.tsx
@@ -1,7 +1,14 @@
 import React, { FunctionComponent } from "react";
 import { Feather } from "@expo/vector-icons";
+import { QRWebIcon } from "../../assets/qr";
 import QRIcon from "../../../assets/icons/qr.svg";
-import { View, TouchableOpacity, StyleSheet, SafeAreaView } from "react-native";
+import {
+  View,
+  TouchableOpacity,
+  StyleSheet,
+  SafeAreaView,
+  Platform
+} from "react-native";
 import { color, shadow } from "../../common/styles";
 import { NavigationProps } from "../../types";
 import { replaceRouteFn } from "../../common/navigation";
@@ -64,15 +71,27 @@ export const BottomNav: FunctionComponent<NavigationProps> = ({
           />
         </NavTab>
         <NavTab onPress={replaceRouteFn(navigation, "QrScannerScreen")}>
-          <QRIcon
-            width={size(2.5)}
-            height={size(2.5)}
-            fill={
-              currentRoute === "QrScannerScreen"
-                ? color("orange", 40)
-                : color("grey", 30)
-            }
-          />
+          {Platform.OS === "web" ? (
+            <QRWebIcon
+              width={size(2)}
+              height={size(2)}
+              fill={
+                currentRoute === "QrScannerScreen"
+                  ? color("orange", 40)
+                  : color("grey", 30)
+              }
+            />
+          ) : (
+            <QRIcon
+              width={size(2.5)}
+              height={size(2.5)}
+              fill={
+                currentRoute === "QrScannerScreen"
+                  ? color("orange", 40)
+                  : color("grey", 30)
+              }
+            />
+          )}
         </NavTab>
         <NavTab onPress={replaceRouteFn(navigation, "SettingsScreen")}>
           <Feather

--- a/src/config/db.tsx
+++ b/src/config/db.tsx
@@ -1,12 +1,20 @@
+import { Platform } from "react-native";
 import { RxJsonSchema, RxCollectionCreator, RxDatabaseCreator } from "rxdb";
 import { DocumentProperties } from "../types";
 
 export const dbName = "idwallet";
 export const dbPassword = "supersecretpassword";
 
+let adapterName;
+if (Platform.OS === "web") {
+  adapterName = "idb";
+} else {
+  adapterName = "react-native-sqlite";
+}
+
 export const db: RxDatabaseCreator = {
   name: dbName,
-  adapter: "react-native-sqlite",
+  adapter: adapterName,
   password: dbPassword,
   multiInstance: false,
   pouchSettings: { skip_setup: true } // eslint-disable-line @typescript-eslint/camelcase

--- a/src/context/network.tsx
+++ b/src/context/network.tsx
@@ -1,5 +1,14 @@
 import React, { createContext, useContext, FunctionComponent } from "react";
-import { useNetInfo } from "@react-native-community/netinfo";
+import { Platform } from "react-native";
+
+let useNetInfo: any;
+if (Platform.OS !== "web") {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const reactNativeCommunity = require("@react-native-community/netinfo");
+  useNetInfo = reactNativeCommunity.useNetInfo;
+} else {
+  useNetInfo = () => ({ isConnected: true });
+}
 
 interface NetworkContext {
   isConnected: boolean;

--- a/src/services/QrProcessor/fetchDocument.tsx
+++ b/src/services/QrProcessor/fetchDocument.tsx
@@ -8,7 +8,7 @@ interface EncryptedDocumentAction {
 
 export const fetchCleartextDocument = async (payload: {
   uri: string;
-}): Promise<OAWrappedDocument> => fetch(payload.uri).then(res => res.json());
+}): Promise<OAWrappedDocument> => fetch(payload.uri).then((res) => res.json());
 
 interface EncryptedResponse {
   tag: string;
@@ -25,7 +25,7 @@ export const fetchEncryptedDocument = async ({
   uri,
   key
 }: EncryptedDocumentAction): Promise<OAWrappedDocument> => {
-  const response: Response = await fetch(uri).then(res => res.json());
+  const response: Response = await fetch(uri).then((res) => res.json());
   const document = response.document || response;
   const { tag, cipherText, iv, type } = document;
 

--- a/src/services/QrProcessor/fetchDocument.tsx
+++ b/src/services/QrProcessor/fetchDocument.tsx
@@ -8,7 +8,7 @@ interface EncryptedDocumentAction {
 
 export const fetchCleartextDocument = async (payload: {
   uri: string;
-}): Promise<OAWrappedDocument> => fetch(payload.uri).then((res) => res.json());
+}): Promise<OAWrappedDocument> => fetch(payload.uri).then(res => res.json());
 
 interface EncryptedResponse {
   tag: string;
@@ -25,7 +25,7 @@ export const fetchEncryptedDocument = async ({
   uri,
   key
 }: EncryptedDocumentAction): Promise<OAWrappedDocument> => {
-  const response: Response = await fetch(uri).then((res) => res.json());
+  const response: Response = await fetch(uri).then(res => res.json());
   const document = response.document || response;
   const { tag, cipherText, iv, type } = document;
 


### PR DESCRIPTION
The goal of this MR is to allow the wallet to run on the browser.

What I have done:
- Created qr.tsx to be used in place of qr.svg when wallet is run on the browser. This is due to incompatibility between react-native-web and svgs.
- Refactor all instances of QRicon to be replaced by QRWebIcon when platform.OS is 'web'
- Setup Rxdb to use pouchdb-adapter-idb instead of SQLite as the adapter when running on web
- Configure useNetInfo to always return true when using react-native-web

What doesn't work:
- The camera module is unable to identity Qr codes
- I am unable to find out the reason